### PR TITLE
Bump dependencies version (Commons CLI 1.9.0, OpenSearch 2.19.2)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@ under the License.
 		<wiremock.version>3.13.1</wiremock.version>
 		<rometools.version>2.1.0</rometools.version>
 		<selenium.version>4.33.0</selenium.version>
-		<cli.version>1.6.0</cli.version>
+		<cli.version>1.9.0</cli.version>
 		<okhttp.version>4.12.0</okhttp.version>
 		<caffeine.version>3.2.1</caffeine.version>
 		<xsoup.version>0.3.7</xsoup.version>

--- a/external/opensearch/pom.xml
+++ b/external/opensearch/pom.xml
@@ -30,7 +30,7 @@ under the License.
 	</parent>
 
 	<properties>
-		<opensearch.version>2.19.1</opensearch.version>
+		<opensearch.version>2.19.2</opensearch.version>
 		<jacoco.haltOnFailure>true</jacoco.haltOnFailure>
 		<jacoco.classRatio>0.27</jacoco.classRatio>
 		<jacoco.instructionRatio>0.27</jacoco.instructionRatio>

--- a/external/opensearch/src/test/java/org/apache/stormcrawler/opensearch/bolt/AbstractOpenSearchTest.java
+++ b/external/opensearch/src/test/java/org/apache/stormcrawler/opensearch/bolt/AbstractOpenSearchTest.java
@@ -25,7 +25,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers(disabledWithoutDocker = true)
 public abstract class AbstractOpenSearchTest {
 
-    private static final String OPENSEARCH_VERSION = "2.17.0";
+    private static final String OPENSEARCH_VERSION = "2.19.2";
 
     public static final String PASSWORD = "This1sAPassw0rd";
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@ under the License.
 		<!-- dependency versions -->
 		<junit.version>5.13.2</junit.version>
 		<storm-client.version>2.8.1</storm-client.version>
-		<jackson.version>2.18.1</jackson.version>
+		<jackson.version>2.19.1</jackson.version>
 		<tika.version>3.2.0</tika.version>
 		<mockito.version>5.18.0</mockito.version>
 		<jetbrains.annotations.version>26.0.2</jetbrains.annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,8 @@ under the License.
 		<!-- dependency versions -->
 		<junit.version>5.13.2</junit.version>
 		<storm-client.version>2.8.1</storm-client.version>
-		<jackson.version>2.19.1</jackson.version>
+		<!-- Jackson's version should be in-line with the one in Storm -->
+		<jackson.version>2.18.1</jackson.version>
 		<tika.version>3.2.0</tika.version>
 		<mockito.version>5.18.0</mockito.version>
 		<jetbrains.annotations.version>26.0.2</jetbrains.annotations.version>


### PR DESCRIPTION
Updates to Jackson-annotations 2.19.1
Updates to Jackson-core 2.19.1
Updates to jackson-databind 2.19.1

Updates to Apache Commons CLI 1.9.0

Updates to opensearch-rest-high-level-client 2.19.2
Updates to opensearch-rest-client-sniffer 2.19.2