### PR TITLE
chore: remove magic number from filterPathRepeat method

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/filtering/basic/BasicURLFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/basic/BasicURLFilter.java
@@ -48,7 +48,11 @@ public class BasicURLFilter extends URLFilter {
     public final String filterPathRepeat(String urlToFilter) {
         // check whether a path element is repeated N times
         String[] paths = urlToFilter.split("/");
-        if (paths.length <= 4) return urlToFilter;
+
+        final int minimumPathLength = 5;
+        // e.g. http://www.example.com/path/path will need 5 parts to have a repetition
+
+        if (paths.length < minimumPathLength) return urlToFilter;
 
         Map<String, Integer> count = new HashMap<>();
         for (String s : paths) {


### PR DESCRIPTION
This PR adds readability in the BasicURLFilter#filterPathRepeat by removing the magic number 4 and adding comments to explain the number