### PR TITLE
Improve MetadataFilter

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/filtering/metadata/MetadataFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/metadata/MetadataFilter.java
@@ -19,8 +19,10 @@ package org.apache.stormcrawler.filtering.metadata;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.function.Predicate;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.filtering.URLFilter;
@@ -29,21 +31,101 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Filter out URLs based on metadata in the source document */
+/** Filter out URLs based on metadata in the source document.
+ * The following json configurations are working perfectly.<br>
+ * Example 1:
+ * <pre>
+ *  {
+ *    "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
+ *    "name": "MetadataFilter",
+ *    "params": {
+ *      "key": "val"
+ *    }
+ *  }
+ * </pre>
+ * Example 2:
+ * <pre>
+ *  {
+ *    "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
+ *    "name": "MetadataFilter",
+ *    "params": {
+ *      "operation": "AND",
+ *      "filters": {
+ *        "key": "val"
+ *      }
+ *    }
+ *  }
+ * </pre>
+ * Example 3:
+ * <pre>
+ *  {
+ *    "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
+ *    "name": "MetadataFilter",
+ *    "params": {
+ *      "operation": "AND",
+ *      "filters": {
+ *        "key": "val",
+ *        "unique_key_for_complex_filtering_1": {
+ *          "operation": "OR",
+ *          "filters": {
+ *            "key2": "val2",
+ *            "key3": "val3"
+ *          }
+ *        }
+ *      }
+ *    }
+ *  }
+ * </pre>
+ */
 public class MetadataFilter extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetadataFilter.class);
+    public static final String COMPLEX_FILTERING_KEY_PREFIX = "unique_key_for_complex_filtering_";
+    public static final String OPERATION_KEY = "operation";
+    public static final String FILTERS_KEY = "filters";
 
     private final ComplexFilter filters = new ComplexFilter();
 
     @Override
     public void configure(@NotNull Map<String, Object> stormConf, @NotNull JsonNode paramNode) {
-        java.util.Iterator<Entry<String, JsonNode>> iter = paramNode.fields();
-        while (iter.hasNext()) {
-            Entry<String, JsonNode> entry = iter.next();
-            String key = entry.getKey();
-            String value = entry.getValue().asText();
-            filters.addFilter(key, value);
+        configure(this.filters,  paramNode);
+    }
+
+    private void configure(@NotNull ComplexFilter filters, @NotNull JsonNode paramNode) {
+        if (!paramNode.has(OPERATION_KEY) &&  !paramNode.has(FILTERS_KEY)) {
+            java.util.Iterator<Entry<String, JsonNode>> iter = paramNode.fields();
+            while (iter.hasNext()) {
+                Entry<String, JsonNode> entry = iter.next();
+                String key = entry.getKey();
+                String value = entry.getValue().asText();
+                filters.addFilter(key, value);
+            }
+        }
+
+        if (paramNode.has(OPERATION_KEY)) {
+            if (paramNode.get(OPERATION_KEY).asText().equalsIgnoreCase("AND")) {
+                filters.setOperation(FilterOperation.AND);
+            } else if (paramNode.get(OPERATION_KEY).asText().equalsIgnoreCase("OR")) {
+                filters.setOperation(FilterOperation.OR);
+            }
+        }
+        if (paramNode.has(FILTERS_KEY)) {
+            paramNode.get(FILTERS_KEY).fields().forEachRemaining(entry -> {
+                String key = entry.getKey();
+                if (!key.startsWith(COMPLEX_FILTERING_KEY_PREFIX)) {
+                    String value = entry.getValue().asText();
+                    filters.addFilter(key, value);
+                }
+            });
+            Iterator<String> fieldNames = paramNode.get(FILTERS_KEY).fieldNames();
+            while (fieldNames.hasNext()) {
+                String fieldName = fieldNames.next();
+                if (fieldName.startsWith(COMPLEX_FILTERING_KEY_PREFIX)) {
+                    ComplexFilter subFilters = new ComplexFilter();
+                    filters.addFilter(subFilters);
+                    configure(subFilters, paramNode.get(FILTERS_KEY).get(fieldName));
+                }
+            }
         }
     }
 
@@ -128,6 +210,24 @@ public class MetadataFilter extends URLFilter {
         };
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MetadataFilter that)) return false;
+        return Objects.equals(filters, that.filters);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(filters);
+    }
+
+    @Override
+    public String toString() {
+        return "MetadataFilter{" +
+                "filters=" + filters +
+                '}';
+    }
+
     public static class ComplexFilter {
         private final Map<String, Object> filters = new HashMap<>();
         private FilterOperation operation = FilterOperation.OR;
@@ -141,12 +241,31 @@ public class MetadataFilter extends URLFilter {
         }
 
         public void addFilter(ComplexFilter filter) {
-            String key = "unique_key_for_complex_filtering_";
+            String key = COMPLEX_FILTERING_KEY_PREFIX;
             int counter = 1;
             while (filters.containsKey(key + counter)) {
                 counter++;
             }
             filters.put(key + counter, filter);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof ComplexFilter that)) return false;
+            return Objects.equals(filters, that.filters) && operation == that.operation;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(filters, operation);
+        }
+
+        @Override
+        public String toString() {
+            return "ComplexFilter{" +
+                    "filters=" + filters +
+                    ", operation=" + operation +
+                    '}';
         }
     }
 

--- a/core/src/main/java/org/apache/stormcrawler/filtering/metadata/MetadataFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/metadata/MetadataFilter.java
@@ -31,9 +31,11 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Filter out URLs based on metadata in the source document.
- * The following json configurations are working perfectly.<br>
+/**
+ * Filter out URLs based on metadata in the source document. The following json configurations are
+ * working perfectly.<br>
  * Example 1:
+ *
  * <pre>
  *  {
  *    "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
@@ -43,7 +45,9 @@ import org.slf4j.LoggerFactory;
  *    }
  *  }
  * </pre>
+ *
  * Example 2:
+ *
  * <pre>
  *  {
  *    "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
@@ -51,12 +55,15 @@ import org.slf4j.LoggerFactory;
  *    "params": {
  *      "operation": "AND",
  *      "filters": {
- *        "key": "val"
+ *        "key": "val",
+ *        "key2": "val2"
  *      }
  *    }
  *  }
  * </pre>
+ *
  * Example 3:
+ *
  * <pre>
  *  {
  *    "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
@@ -88,11 +95,11 @@ public class MetadataFilter extends URLFilter {
 
     @Override
     public void configure(@NotNull Map<String, Object> stormConf, @NotNull JsonNode paramNode) {
-        configure(this.filters,  paramNode);
+        configure(this.filters, paramNode);
     }
 
     private void configure(@NotNull ComplexFilter filters, @NotNull JsonNode paramNode) {
-        if (!paramNode.has(OPERATION_KEY) &&  !paramNode.has(FILTERS_KEY)) {
+        if (!paramNode.has(OPERATION_KEY) && !paramNode.has(FILTERS_KEY)) {
             java.util.Iterator<Entry<String, JsonNode>> iter = paramNode.fields();
             while (iter.hasNext()) {
                 Entry<String, JsonNode> entry = iter.next();
@@ -110,13 +117,17 @@ public class MetadataFilter extends URLFilter {
             }
         }
         if (paramNode.has(FILTERS_KEY)) {
-            paramNode.get(FILTERS_KEY).fields().forEachRemaining(entry -> {
-                String key = entry.getKey();
-                if (!key.startsWith(COMPLEX_FILTERING_KEY_PREFIX)) {
-                    String value = entry.getValue().asText();
-                    filters.addFilter(key, value);
-                }
-            });
+            paramNode
+                    .get(FILTERS_KEY)
+                    .fields()
+                    .forEachRemaining(
+                            entry -> {
+                                String key = entry.getKey();
+                                if (!key.startsWith(COMPLEX_FILTERING_KEY_PREFIX)) {
+                                    String value = entry.getValue().asText();
+                                    filters.addFilter(key, value);
+                                }
+                            });
             Iterator<String> fieldNames = paramNode.get(FILTERS_KEY).fieldNames();
             while (fieldNames.hasNext()) {
                 String fieldName = fieldNames.next();
@@ -223,9 +234,7 @@ public class MetadataFilter extends URLFilter {
 
     @Override
     public String toString() {
-        return "MetadataFilter{" +
-                "filters=" + filters +
-                '}';
+        return "MetadataFilter{" + "filters=" + filters + '}';
     }
 
     public static class ComplexFilter {
@@ -262,10 +271,7 @@ public class MetadataFilter extends URLFilter {
 
         @Override
         public String toString() {
-            return "ComplexFilter{" +
-                    "filters=" + filters +
-                    ", operation=" + operation +
-                    '}';
+            return "ComplexFilter{" + "filters=" + filters + ", operation=" + operation + '}';
         }
     }
 

--- a/core/src/main/java/org/apache/stormcrawler/filtering/metadata/MetadataFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/metadata/MetadataFilter.java
@@ -18,9 +18,10 @@ package org.apache.stormcrawler.filtering.metadata;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URL;
-import java.util.LinkedList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Predicate;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.filtering.URLFilter;
 import org.jetbrains.annotations.NotNull;
@@ -33,7 +34,7 @@ public class MetadataFilter extends URLFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetadataFilter.class);
 
-    private final LinkedList<String[]> mdFilters = new LinkedList<>();
+    private final ComplexFilter filters = new ComplexFilter();
 
     @Override
     public void configure(@NotNull Map<String, Object> stormConf, @NotNull JsonNode paramNode) {
@@ -42,8 +43,20 @@ public class MetadataFilter extends URLFilter {
             Entry<String, JsonNode> entry = iter.next();
             String key = entry.getKey();
             String value = entry.getValue().asText();
-            mdFilters.add(new String[] {key, value});
+            filters.addFilter(key, value);
         }
+    }
+
+    public void addFilter(String key, String value) {
+        filters.addFilter(key, value);
+    }
+
+    public void addFilter(ComplexFilter filter) {
+        filters.addFilter(filter);
+    }
+
+    public void setOperation(FilterOperation operation) {
+        filters.setOperation(operation);
     }
 
     @Override
@@ -52,19 +65,93 @@ public class MetadataFilter extends URLFilter {
         if (sourceMetadata == null) {
             return urlToFilter;
         }
-        // check whether any of the metadata can be found in the source
-        for (String[] kv : mdFilters) {
-            String[] vals = sourceMetadata.getValues(kv[0]);
-            if (vals == null) {
-                continue;
+        if (sourceMetadata.asMap().isEmpty()) {
+            return urlToFilter;
+        }
+        if (filters.filters.isEmpty()) {
+            return urlToFilter;
+        }
+
+        boolean shouldFilter =
+                recursiveFilter(filters.operation, filters, sourceMetadata, urlToFilter);
+        if (shouldFilter) {
+            return null;
+        }
+
+        return urlToFilter;
+    }
+
+    private static boolean recursiveFilter(
+            FilterOperation operation,
+            ComplexFilter complexFilter,
+            Metadata sourceMetadata,
+            String urlToFilter) {
+        if (operation == FilterOperation.OR) {
+            return complexFilter.filters.entrySet().stream()
+                    .anyMatch(getPredicate(sourceMetadata, urlToFilter));
+        } else if (operation == FilterOperation.AND) {
+            return complexFilter.filters.entrySet().stream()
+                    .allMatch(getPredicate(sourceMetadata, urlToFilter));
+        }
+        return false;
+    }
+
+    private static @NotNull Predicate<Entry<String, Object>> getPredicate(
+            Metadata sourceMetadata, String urlToFilter) {
+        return entrySet -> {
+            if (entrySet.getValue() instanceof ComplexFilter) {
+                return recursiveFilter(
+                        ((ComplexFilter) entrySet.getValue()).operation,
+                        (ComplexFilter) entrySet.getValue(),
+                        sourceMetadata,
+                        urlToFilter);
             }
+            String[] vals = sourceMetadata.getValues(entrySet.getKey());
+            if (vals == null) {
+                return false;
+            }
+
             for (String v : vals) {
-                if (v.equalsIgnoreCase(kv[1])) {
-                    LOG.debug("Filtering {} matching metadata {}:{}", urlToFilter, kv[0], kv[1]);
-                    return null;
+                if (entrySet.getValue() instanceof String) {
+                    if (v.equalsIgnoreCase((String) entrySet.getValue())) {
+                        LOG.debug(
+                                "Filtering {} matching metadata {}:{}",
+                                urlToFilter,
+                                entrySet.getKey(),
+                                entrySet.getValue());
+                        return true;
+                    }
                 }
             }
+
+            return false;
+        };
+    }
+
+    public static class ComplexFilter {
+        private final Map<String, Object> filters = new HashMap<>();
+        private FilterOperation operation = FilterOperation.OR;
+
+        public void setOperation(FilterOperation operation) {
+            this.operation = operation;
         }
-        return urlToFilter;
+
+        public void addFilter(String key, String value) {
+            filters.put(key, value);
+        }
+
+        public void addFilter(ComplexFilter filter) {
+            String key = "unique_key_for_complex_filtering_";
+            int counter = 1;
+            while (filters.containsKey(key + counter)) {
+                counter++;
+            }
+            filters.put(key + counter, filter);
+        }
+    }
+
+    public enum FilterOperation {
+        OR,
+        AND
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterFromJsonTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterFromJsonTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.stormcrawler.filtering;
+
+import org.apache.stormcrawler.Metadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+class MetadataFilterFromJsonTest {
+
+    private URLFilters createURLFilters(String configFile) {
+        return URLFilters.fromConf(Map.of("urlfilters.config.file", configFile));
+    }
+
+    // old filter mechanism (backward compatible)
+    @Test
+    void testFilterNoMD() throws MalformedURLException {
+        URLFilters filter = createURLFilters("test.metadata.1.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testFilterHit() throws MalformedURLException {
+        URLFilters filter = createURLFilters("test.metadata.1.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+    }
+
+    @Test
+    void testFilterNoHit() throws MalformedURLException {
+        URLFilters filter = createURLFilters("test.metadata.1.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val2");
+        metadata.addValue("key", "val3");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    // new filter mechanism
+    @Test
+    void testNewFilterWithEmptyFilterAndNullMetadata() throws MalformedURLException {
+        URLFilters filter = createURLFilters("test.metadata.2.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        String filterResult = filter.filter(url, null, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithEmptyFilterAndEmptyMetadata() throws MalformedURLException {
+        URLFilters filter = createURLFilters("test.metadata.2.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithEmptyMetadata() throws MalformedURLException {
+        URLFilters filter = createURLFilters("test.metadata.2.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithOnlyOneMatchingANDFilter() throws MalformedURLException {
+        // Filter if key=>val AND key2=>val2 match
+        URLFilters filter = createURLFilters("test.metadata.2.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithAllMatchingANDFilter() throws MalformedURLException {
+        // Filter if key=>val AND key2=>val2 match
+        URLFilters filter = createURLFilters("test.metadata.2.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key2", "val2");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+    }
+
+    @Test
+    void testNewFilterWithComplexFilter() throws MalformedURLException {
+        // Filter if key=>val AND (key2=>val2 OR key3=>val3) match
+        URLFilters filter = createURLFilters("test.metadata.3.urlfilters.json");
+        URL url = new URL("http://www.sourcedomain.com/");
+
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key2", "val2");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key2", "val2");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key2", "val2");
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterFromJsonTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterFromJsonTest.java
@@ -16,13 +16,12 @@
  */
 package org.apache.stormcrawler.filtering;
 
-import org.apache.stormcrawler.Metadata;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
+import org.apache.stormcrawler.Metadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class MetadataFilterFromJsonTest {
 

--- a/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterTest.java
@@ -266,7 +266,7 @@ class MetadataFilterTest {
         Assertions.assertNull(filterResult);
     }
 
-    //configure() backward compatible
+    // configure() backward compatible
     @Test
     void testConfigureBackwardCompatible() {
         MetadataFilter filter = new MetadataFilter();
@@ -281,7 +281,7 @@ class MetadataFilterTest {
         Assertions.assertEquals(expectedFilter, filter);
     }
 
-    //new configure()
+    // new configure()
     @Test
     void testNewConfigure() {
         MetadataFilter filter = new MetadataFilter();
@@ -302,10 +302,6 @@ class MetadataFilterTest {
 
     @Test
     void testNewConfigureWithComplexFilter() {
-        /*
-        *
-        * */
-
         MetadataFilter filter = new MetadataFilter();
         ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
         filterParams.put("operation", "OR");

--- a/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterTest.java
@@ -265,4 +265,72 @@ class MetadataFilterTest {
         filterResult = filter.filter(url, metadata, url.toExternalForm());
         Assertions.assertNull(filterResult);
     }
+
+    //configure() backward compatible
+    @Test
+    void testConfigureBackwardCompatible() {
+        MetadataFilter filter = new MetadataFilter();
+        ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
+        filterParams.put("key", "val");
+        Map<String, Object> conf = new HashMap<>();
+        filter.configure(conf, filterParams);
+
+        MetadataFilter expectedFilter = new MetadataFilter();
+        expectedFilter.addFilter("key", "val");
+
+        Assertions.assertEquals(expectedFilter, filter);
+    }
+
+    //new configure()
+    @Test
+    void testNewConfigure() {
+        MetadataFilter filter = new MetadataFilter();
+        ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
+        filterParams.put("operation", "AND");
+        ObjectNode filters = new ObjectNode(JsonNodeFactory.instance);
+        filters.put("key", "val");
+        filterParams.set("filters", filters);
+        Map<String, Object> conf = new HashMap<>();
+        filter.configure(conf, filterParams);
+
+        MetadataFilter expectedFilter = new MetadataFilter();
+        expectedFilter.addFilter("key", "val");
+        expectedFilter.setOperation(MetadataFilter.FilterOperation.AND);
+
+        Assertions.assertEquals(expectedFilter, filter);
+    }
+
+    @Test
+    void testNewConfigureWithComplexFilter() {
+        /*
+        *
+        * */
+
+        MetadataFilter filter = new MetadataFilter();
+        ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
+        filterParams.put("operation", "OR");
+        ObjectNode filters = new ObjectNode(JsonNodeFactory.instance);
+        filters.put("key", "val");
+        ObjectNode filters2 = new ObjectNode(JsonNodeFactory.instance);
+        filters2.put("operation", "AND");
+        ObjectNode subfilters = new ObjectNode(JsonNodeFactory.instance);
+        subfilters.put("key2", "val2");
+        subfilters.put("key3", "val3");
+        filters2.set("filters", subfilters);
+        filters.set("unique_key_for_complex_filtering_1", filters2);
+        filterParams.set("filters", filters);
+        Map<String, Object> conf = new HashMap<>();
+        filter.configure(conf, filterParams);
+
+        // Filter if key=>val OR (key2=>val2 AND key3=>val3) match
+        MetadataFilter expectedFilter = new MetadataFilter();
+        expectedFilter.addFilter("key", "val");
+        MetadataFilter.ComplexFilter filter2 = new MetadataFilter.ComplexFilter();
+        filter2.addFilter("key2", "val2");
+        filter2.addFilter("key3", "val3");
+        filter2.setOperation(MetadataFilter.FilterOperation.AND);
+        expectedFilter.addFilter(filter2);
+
+        Assertions.assertEquals(expectedFilter, filter);
+    }
 }

--- a/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/MetadataFilterTest.java
@@ -38,6 +38,7 @@ class MetadataFilterTest {
         return filter;
     }
 
+    // old filter mechanism (backward compatible)
     @Test
     void testFilterNoMD() throws MalformedURLException {
         URLFilter filter = createFilter("key", "val");
@@ -66,5 +67,202 @@ class MetadataFilterTest {
         metadata.addValue("key", "val3");
         String filterResult = filter.filter(url, metadata, url.toExternalForm());
         Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    // new filter mechanism
+    @Test
+    void testNewFilterWithEmptyFilterAndNullMetadata() throws MalformedURLException {
+        MetadataFilter filter = new MetadataFilter();
+        URL url = new URL("http://www.sourcedomain.com/");
+        String filterResult = filter.filter(url, null, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithEmptyFilterAndEmptyMetadata() throws MalformedURLException {
+        MetadataFilter filter = new MetadataFilter();
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithEmptyFilter() throws MalformedURLException {
+        MetadataFilter filter = new MetadataFilter();
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithEmptyMetadata() throws MalformedURLException {
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithSingleMatchingORFilter() throws MalformedURLException {
+        // Filter if key=>val match (OR operation)
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+    }
+
+    @Test
+    void testNewFilterWithSingleMatchingANDFilter() throws MalformedURLException {
+        // Filter if key=>val match (AND operation)
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        filter.setOperation(MetadataFilter.FilterOperation.AND);
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+    }
+
+    @Test
+    void testNewFilterWithOnlyOneMatchingORFilter() throws MalformedURLException {
+        // Filter if key=>val OR key2=>val2 match
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        filter.addFilter("key2", "val2");
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+    }
+
+    @Test
+    void testNewFilterWithOnlyOneMatchingANDFilter() throws MalformedURLException {
+        // Filter if key=>val AND key2=>val2 match
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        filter.addFilter("key2", "val2");
+        filter.setOperation(MetadataFilter.FilterOperation.AND);
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithAllMatchingANDFilter() throws MalformedURLException {
+        // Filter if key=>val AND key2=>val2 match
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        filter.addFilter("key2", "val2");
+        filter.setOperation(MetadataFilter.FilterOperation.AND);
+        URL url = new URL("http://www.sourcedomain.com/");
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key2", "val2");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+    }
+
+    @Test
+    void testNewFilterWithComplexFilter() throws MalformedURLException {
+        // Filter if key=>val AND (key2=>val2 OR key3=>val3) match
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        filter.setOperation(MetadataFilter.FilterOperation.AND);
+        MetadataFilter.ComplexFilter filter2 = new MetadataFilter.ComplexFilter();
+        filter2.addFilter("key2", "val2");
+        filter2.addFilter("key3", "val3");
+        filter.addFilter(filter2);
+        URL url = new URL("http://www.sourcedomain.com/");
+
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key2", "val2");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key2", "val2");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key2", "val2");
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+    }
+
+    @Test
+    void testNewFilterWithOtherComplexFilter() throws MalformedURLException {
+        // Filter if key=>val OR (key2=>val2 AND key3=>val3) match
+        MetadataFilter filter = new MetadataFilter();
+        filter.addFilter("key", "val");
+        MetadataFilter.ComplexFilter filter2 = new MetadataFilter.ComplexFilter();
+        filter2.addFilter("key2", "val2");
+        filter2.addFilter("key3", "val3");
+        filter2.setOperation(MetadataFilter.FilterOperation.AND);
+        filter.addFilter(filter2);
+        URL url = new URL("http://www.sourcedomain.com/");
+
+        Metadata metadata = new Metadata();
+        metadata.addValue("key", "val");
+        String filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key2", "val2");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key2", "val2");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertEquals(url.toExternalForm(), filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key", "val");
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
+
+        metadata = new Metadata();
+        metadata.addValue("key2", "val2");
+        metadata.addValue("key3", "val3");
+        filterResult = filter.filter(url, metadata, url.toExternalForm());
+        Assertions.assertNull(filterResult);
     }
 }

--- a/core/src/test/resources/test.metadata.1.urlfilters.json
+++ b/core/src/test/resources/test.metadata.1.urlfilters.json
@@ -1,0 +1,11 @@
+{
+  "org.apache.stormcrawler.filtering.URLFilters": [
+    {
+      "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
+      "name": "MetadataFilter",
+      "params": {
+        "key": "val"
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/test.metadata.2.urlfilters.json
+++ b/core/src/test/resources/test.metadata.2.urlfilters.json
@@ -1,0 +1,15 @@
+{
+  "org.apache.stormcrawler.filtering.URLFilters": [
+    {
+      "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
+      "name": "MetadataFilter",
+      "params": {
+        "operation": "AND",
+        "filters": {
+          "key": "val",
+          "key2": "val2"
+        }
+      }
+    }
+  ]
+}

--- a/core/src/test/resources/test.metadata.3.urlfilters.json
+++ b/core/src/test/resources/test.metadata.3.urlfilters.json
@@ -1,0 +1,21 @@
+{
+  "org.apache.stormcrawler.filtering.URLFilters": [
+    {
+      "class": "org.apache.stormcrawler.filtering.metadata.MetadataFilter",
+      "name": "MetadataFilter",
+      "params": {
+        "operation": "AND",
+        "filters": {
+          "key": "val",
+          "unique_key_for_complex_filtering_1": {
+            "operation": "OR",
+            "filters": {
+              "key2": "val2",
+              "key3": "val3"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request suppose to address the #711 issue.

I created a complex filtering logic where any operation can be assembled.
E.g.: I created test cases where these are the filters
- key=>val OR (key2=>val2 AND key3=>val3)
- key=>val AND (key2=>val2 OR key3=>val3)

What do you think?