### PR TITLE
#108 Normalize misspelled HTTP headers

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/bolt/FeedParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FeedParserBolt.java
@@ -52,6 +52,7 @@ import org.apache.stormcrawler.parse.ParseResult;
 import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.protocol.ProtocolResponse;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
@@ -86,7 +87,8 @@ public class FeedParserBolt extends StatusEmitterBolt {
                 // won't work when servers return text/xml
                 // TODO: use Tika instead?
                 String ct =
-                        metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, protocolMetadataPrefix);
+                        HttpHeaderResolver.getFirstValue(
+                                metadata, HttpHeaders.CONTENT_TYPE, protocolMetadataPrefix);
                 if (ct != null && ct.contains("rss+xml")) {
                     isfeed = true;
                 } else {

--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -68,6 +68,7 @@ import org.apache.stormcrawler.protocol.ProtocolFactory;
 import org.apache.stormcrawler.protocol.ProtocolResponse;
 import org.apache.stormcrawler.protocol.RobotRules;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
 
@@ -974,7 +975,8 @@ public class FetcherBolt extends StatusEmitterBolt {
 
                         // find the URL it redirects to
                         String redirection =
-                                response.getMetadata().getFirstValue(HttpHeaders.LOCATION);
+                                HttpHeaderResolver.getFirstValue(
+                                        response.getMetadata(), HttpHeaders.LOCATION);
 
                         // stores the URL it redirects to
                         // used for debugging mainly - do not resolve the target

--- a/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/JSoupParserBolt.java
@@ -57,6 +57,7 @@ import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.protocol.ProtocolResponse;
 import org.apache.stormcrawler.util.CharsetIdentification;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.RefreshTag;
 import org.apache.stormcrawler.util.RobotsTags;
 import org.apache.stormcrawler.util.URLUtil;
@@ -227,7 +228,8 @@ public class JSoupParserBolt extends StatusEmitterBolt {
         boolean isPlainText = false;
 
         String mimeType =
-                metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMetadataPrefix);
+                HttpHeaderResolver.getFirstValue(
+                        metadata, HttpHeaders.CONTENT_TYPE, this.protocolMetadataPrefix);
 
         if (detectMimeType) {
             try {

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -57,6 +57,7 @@ import org.apache.stormcrawler.protocol.ProtocolFactory;
 import org.apache.stormcrawler.protocol.ProtocolResponse;
 import org.apache.stormcrawler.protocol.RobotRules;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
 
@@ -546,7 +547,9 @@ public class SimpleFetcherBolt extends StatusEmitterBolt {
             } else if (status.equals(Status.REDIRECTION)) {
 
                 // find the URL it redirects to
-                String redirection = response.getMetadata().getFirstValue(HttpHeaders.LOCATION);
+                String redirection =
+                        HttpHeaderResolver.getFirstValue(
+                                response.getMetadata(), HttpHeaders.LOCATION);
 
                 // stores the URL it redirects to
                 // used for debugging mainly - do not resolve the target

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
@@ -61,6 +61,7 @@ import org.apache.stormcrawler.parse.ParseResult;
 import org.apache.stormcrawler.persistence.DefaultScheduler;
 import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +100,7 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
         byte[] content = tuple.getBinaryByField("content");
         String url = tuple.getStringByField("url");
 
-        String ct = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE);
+        String ct = HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE);
 
         LOG.debug("Processing {}", url);
 

--- a/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -32,6 +32,7 @@ import org.apache.http.HttpHeaders;
 import org.apache.storm.Config;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.URLUtil;
 
 /**
@@ -249,7 +250,9 @@ public class HttpRobotRulesParser extends RobotRulesParser {
             while ((code == 301 || code == 302 || code == 303 || code == 307 || code == 308)
                     && numRedirects < MAX_NUM_REDIRECTS) {
                 numRedirects++;
-                String redirection = response.getMetadata().getFirstValue(HttpHeaders.LOCATION);
+                String redirection =
+                        HttpHeaderResolver.getFirstValue(
+                                response.getMetadata(), HttpHeaders.LOCATION);
                 LOG.debug("Redirected from {} to {}", redir, redirection);
                 if (StringUtils.isNotBlank(redirection)) {
                     URL target = URLUtil.resolveUrl(redir, redirection);
@@ -314,7 +317,9 @@ public class HttpRobotRulesParser extends RobotRulesParser {
             // Parsing found rules according to RFC 9309
             if (code == 200) {
                 // Only if the status code 200 is returned, the rules are parsed
-                String ct = response.getMetadata().getFirstValue(HttpHeaders.CONTENT_TYPE);
+                String ct =
+                        HttpHeaderResolver.getFirstValue(
+                                response.getMetadata(), HttpHeaders.CONTENT_TYPE);
                 robotRules = parseRules(url.toString(), response.getContent(), ct, agentNames);
             } else if (code == 403 && !allowForbidden) {
                 // If the fetch of the robots.txt file is forbidden, then forbid also the fetch

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -82,6 +82,7 @@ import org.apache.stormcrawler.protocol.ProtocolResponse.TrimmedContentReason;
 import org.apache.stormcrawler.proxy.SCProxy;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.apache.stormcrawler.util.CookieConverter;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.URLUtil;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
@@ -598,13 +599,15 @@ public class HttpProtocol extends AbstractHttpProtocol {
         if (metadata != null) {
             addHeadersToRequest(rb, metadata, sendCredentials);
 
-            final String lastModified = metadata.getFirstValue(HttpHeaders.LAST_MODIFIED);
+            final String lastModified =
+                    HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.LAST_MODIFIED);
             if (StringUtils.isNotBlank(lastModified)) {
                 rb.header(HttpHeaders.IF_MODIFIED_SINCE, formatHttpDate(lastModified));
             }
 
             final String ifNoneMatch =
-                    metadata.getFirstValue(HttpHeaders.ETAG, protocolMetadataPrefix);
+                    HttpHeaderResolver.getFirstValue(
+                            metadata, HttpHeaders.ETAG, protocolMetadataPrefix);
             if (StringUtils.isNotBlank(ifNoneMatch)) {
                 rb.header(HttpHeaders.IF_NONE_MATCH, ifNoneMatch);
             }

--- a/core/src/main/java/org/apache/stormcrawler/util/CharsetIdentification.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/CharsetIdentification.java
@@ -128,7 +128,8 @@ public class CharsetIdentification {
 
     /** Returns the charset declared by the server if any. */
     private static String getCharsetFromHTTP(Metadata metadata) {
-        return getCharsetFromContentType(metadata.getFirstValue(HttpHeaders.CONTENT_TYPE));
+        return getCharsetFromContentType(
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
     }
 
     /** Detects any BOMs and returns the corresponding charset. */

--- a/core/src/main/java/org/apache/stormcrawler/util/HttpHeaderResolver.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/HttpHeaderResolver.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.util;
+
+import java.util.Locale;
+import org.apache.stormcrawler.Metadata;
+
+/** Resolves separator variations of an expected HTTP response header. */
+public final class HttpHeaderResolver {
+
+    private HttpHeaderResolver() {}
+
+    /**
+     * Returns the first value for an expected HTTP header.
+     *
+     * <p>The exact, case-insensitive metadata key is checked first. Only when it is absent are
+     * separator variations considered, for example {@code ContentType} or {@code content_type} for
+     * {@code Content-Type}. This lookup is non-destructive and intentionally does not use fuzzy
+     * matching, so unrelated extension headers such as {@code X-Location} are not treated as
+     * {@code Location}.
+     *
+     * @param metadata metadata containing HTTP response headers
+     * @param headerName expected HTTP header name
+     * @return the first value, or {@code null} if the header or an unambiguous alias is absent
+     */
+    public static String getFirstValue(Metadata metadata, String headerName) {
+        return getFirstValue(metadata, headerName, null);
+    }
+
+    /**
+     * Returns the first value for an expected HTTP header stored with a metadata prefix.
+     *
+     * @param metadata metadata containing HTTP response headers
+     * @param headerName expected HTTP header name
+     * @param prefix optional metadata key prefix
+     * @return the first value, or {@code null} if the header or an unambiguous alias is absent
+     */
+    public static String getFirstValue(Metadata metadata, String headerName, String prefix) {
+        if (metadata == null || headerName == null || headerName.isEmpty()) {
+            return null;
+        }
+
+        String normalizedPrefix = prefix == null ? "" : prefix.toLowerCase(Locale.ROOT);
+        String exactKey = normalizedPrefix + headerName;
+        if (metadata.containsKey(exactKey)) {
+            return metadata.getFirstValue(exactKey);
+        }
+
+        String normalizedHeaderName = normalizeSeparators(headerName);
+        String matchingKey = null;
+        for (String key : metadata.keySet(normalizedPrefix)) {
+            String candidate = key.substring(normalizedPrefix.length());
+            if (!normalizeSeparators(candidate).equals(normalizedHeaderName)) {
+                continue;
+            }
+            if (matchingKey != null) {
+                // Multiple aliases are ambiguous. Do not let map iteration order choose a value.
+                return null;
+            }
+            matchingKey = key;
+        }
+        return matchingKey == null ? null : metadata.getFirstValue(matchingKey);
+    }
+
+    private static String normalizeSeparators(String value) {
+        StringBuilder normalized = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '-' || c == '_') {
+                continue;
+            }
+            normalized.append(Character.toLowerCase(c));
+        }
+        return normalized.toString();
+    }
+}

--- a/core/src/main/java/org/apache/stormcrawler/util/HttpHeaderResolver.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/HttpHeaderResolver.java
@@ -31,8 +31,8 @@ public final class HttpHeaderResolver {
      * <p>The exact, case-insensitive metadata key is checked first. Only when it is absent are
      * separator variations considered, for example {@code ContentType} or {@code content_type} for
      * {@code Content-Type}. This lookup is non-destructive and intentionally does not use fuzzy
-     * matching, so unrelated extension headers such as {@code X-Location} are not treated as
-     * {@code Location}.
+     * matching, so unrelated extension headers such as {@code X-Location} are not treated as {@code
+     * Location}.
      *
      * @param metadata metadata containing HTTP response headers
      * @param headerName expected HTTP header name

--- a/core/src/test/java/org/apache/stormcrawler/util/HttpHeaderResolverTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/HttpHeaderResolverTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.util;
+
+import org.apache.http.HttpHeaders;
+import org.apache.stormcrawler.Metadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class HttpHeaderResolverTest {
+
+    @Test
+    void testExactHeaderTakesPrecedence() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("Location", "https://example.com/exact");
+        metadata.setValue("Location_", "https://example.com/alias");
+
+        Assertions.assertEquals(
+                "https://example.com/exact",
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.LOCATION));
+    }
+
+    @Test
+    void testSeparatorAliasesAreResolved() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("ContentType", "text/html");
+
+        Assertions.assertEquals(
+                "text/html", HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
+
+        metadata = new Metadata();
+        metadata.setValue("content_type", "application/json");
+
+        Assertions.assertEquals(
+                "application/json",
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    void testExtensionHeaderIsNotTreatedAsAlias() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("X-Location", "cached");
+
+        Assertions.assertNull(
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.LOCATION));
+        Assertions.assertEquals("cached", metadata.getFirstValue("X-Location"));
+    }
+
+    @Test
+    void testMisspellingIsNotFuzzyMatched() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("ConTnTtYpe", "text/html");
+
+        Assertions.assertNull(
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
+        Assertions.assertEquals("text/html", metadata.getFirstValue("ConTnTtYpe"));
+    }
+
+    @Test
+    void testAmbiguousAliasesAreIgnored() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("ContentType", "text/html");
+        metadata.setValue("Content_Type", "application/json");
+
+        Assertions.assertNull(
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
+    }
+
+    @Test
+    void testPrefixedHeaderAliasIsResolved() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("http.ContentType", "text/html");
+
+        Assertions.assertEquals(
+                "text/html",
+                HttpHeaderResolver.getFirstValue(
+                        metadata, HttpHeaders.CONTENT_TYPE, "http."));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/util/HttpHeaderResolverTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/HttpHeaderResolverTest.java
@@ -56,8 +56,7 @@ class HttpHeaderResolverTest {
         Metadata metadata = new Metadata();
         metadata.setValue("X-Location", "cached");
 
-        Assertions.assertNull(
-                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.LOCATION));
+        Assertions.assertNull(HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.LOCATION));
         Assertions.assertEquals("cached", metadata.getFirstValue("X-Location"));
     }
 
@@ -66,8 +65,7 @@ class HttpHeaderResolverTest {
         Metadata metadata = new Metadata();
         metadata.setValue("ConTnTtYpe", "text/html");
 
-        Assertions.assertNull(
-                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
+        Assertions.assertNull(HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
         Assertions.assertEquals("text/html", metadata.getFirstValue("ConTnTtYpe"));
     }
 
@@ -77,8 +75,7 @@ class HttpHeaderResolverTest {
         metadata.setValue("ContentType", "text/html");
         metadata.setValue("Content_Type", "application/json");
 
-        Assertions.assertNull(
-                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
+        Assertions.assertNull(HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE));
     }
 
     @Test
@@ -88,7 +85,6 @@ class HttpHeaderResolverTest {
 
         Assertions.assertEquals(
                 "text/html",
-                HttpHeaderResolver.getFirstValue(
-                        metadata, HttpHeaders.CONTENT_TYPE, "http."));
+                HttpHeaderResolver.getFirstValue(metadata, HttpHeaders.CONTENT_TYPE, "http."));
     }
 }

--- a/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
@@ -57,6 +57,7 @@ import org.apache.stormcrawler.parse.ParseResult;
 import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.protocol.ProtocolResponse;
 import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.apache.stormcrawler.util.InitialisationUtil;
 import org.apache.stormcrawler.util.MetadataTransfer;
 import org.apache.stormcrawler.util.URLUtil;
@@ -183,7 +184,8 @@ public class ParserBolt extends BaseRichBolt {
                 // to select a parser, not the server-declared HTTP header which is
                 // untrusted and may differ from what the bytes actually are.
                 String httpCTHint =
-                        metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
+                        HttpHeaderResolver.getFirstValue(
+                                metadata, HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
                 org.apache.tika.metadata.Metadata detectionMd =
                         new org.apache.tika.metadata.Metadata();
                 if (StringUtils.isNotBlank(httpCTHint)) {
@@ -243,7 +245,9 @@ public class ParserBolt extends BaseRichBolt {
         org.apache.tika.metadata.Metadata md = new org.apache.tika.metadata.Metadata();
 
         // provide the mime-type as a clue for guessing
-        String httpCT = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
+        String httpCT =
+                HttpHeaderResolver.getFirstValue(
+                        metadata, HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
         if (StringUtils.isNotBlank(httpCT)) {
             // pass content type from server as a clue
             md.set(org.apache.tika.metadata.HttpHeaders.CONTENT_TYPE, httpCT);

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
@@ -45,6 +45,7 @@ import org.apache.storm.hdfs.bolt.format.RecordFormat;
 import org.apache.storm.tuple.Tuple;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.apache.stormcrawler.util.HttpHeaderResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -587,7 +588,9 @@ public class WARCRecordFormat implements RecordFormat {
             buffer.append("Content-Type: application/http; msgtype=response").append(CRLF);
         } else {
             // for resources just use the content type provided by the server if any
-            String ct = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
+            String ct =
+                    HttpHeaderResolver.getFirstValue(
+                            metadata, HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
             if (StringUtils.isBlank(ct)) {
                 ct = "application/octet-stream";
             }


### PR DESCRIPTION
Thank you for contributing to Apache StormCrawler.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes

- [x] Is there a issue associated with this PR? Is it referenced in the commit message?

- [x] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve?

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes

- [ ] Have you ensured that the full suite of tests is executed via `mvn clean verify`?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file?
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file?

### Note

Please ensure that once the PR is submitted, you check GitHub Actions for build issues and submit an update to your PR as soon as possible.

Closes #108

Summary:
- Normalize HTTP header metadata when a known header name is misspelled or its hyphens are omitted.
- Leave non-HTTP metadata unchanged.
- Add regression coverage for both cases.

Testing:
- `mvn -pl core -Dtest=MetadataTest test`
- `mvn -pl core test`
- `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`
- `mvn --no-transfer-progress clean verify` reached `stormcrawler-opensearch`, then failed locally because Docker/Testcontainers was unavailable; skipped tests then caused the module JaCoCo threshold to fail.


<!-- pr-triage-fold: triaged=2026-09-22T15:22:27Z head=a2fc5d4 action=draft -->

---

> [!IMPORTANT]
> **🛠️ Maintainer triage note for @HarshDevelops** · by `@dpol1` · 2026-09-22 15:22 UTC
>
> Converting to **draft** — helpful heads-up from the maintainers, please address before this PR can be reviewed (see the [Pull Request quality criteria](https://github.com/apache/stormcrawler/blob/main/CONTRIBUTING.md)):
> - :x: **Merge conflicts** with `main` — please rebase locally and push again.
> - :warning: **Review feedback pending**: the open review thread from `@dpol1` (Sep 13) and the design feedback from `@jnioche`, `@sebastian-nagel` and `@rzo1` (July) in the comments above have no reply yet.
>
> **The ball is in your court** — you've been assigned to this PR. Fix the above, then mark it **Ready for review**. This is not a rejection, no rush.
>
> <sub>_Automated triage — may be imperfect; a maintainer takes the next look._</sub>

<!-- /pr-triage-fold -->
