### PR TITLE
#1998 WARC writer: WARC-Protocol header to follow WARC field proposals

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/protocol/ProtocolResponse.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/ProtocolResponse.java
@@ -46,6 +46,12 @@ public class ProtocolResponse {
     public static final String PROTOCOL_VERSIONS_KEY = "_protocol_versions_";
 
     /**
+     * Key which holds the SSL/TLS cipher suites. For requests sent over http:// the value may be
+     * null.
+     */
+    public static final String CIPHER_SUITES_KEY = "_cipher_suites_";
+
+    /**
      * Metadata key which holds a boolean value in metadata whether the response content is trimmed
      * or not.
      */

--- a/core/src/main/java/org/apache/stormcrawler/protocol/ProtocolResponse.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/ProtocolResponse.java
@@ -46,10 +46,10 @@ public class ProtocolResponse {
     public static final String PROTOCOL_VERSIONS_KEY = "_protocol_versions_";
 
     /**
-     * Key which holds the SSL/TLS cipher suites. For requests sent over http:// the value may be
-     * null.
+     * Key which holds the SSL/TLS cipher suite. Not set if the request was sent over an unencrypted
+     * connection (http://).
      */
-    public static final String CIPHER_SUITES_KEY = "_cipher_suites_";
+    public static final String CIPHER_SUITE_KEY = "_cipher_suite_";
 
     /**
      * Metadata key which holds a boolean value in metadata whether the response content is trimmed

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -669,10 +669,11 @@ public class HttpProtocol extends AbstractHttpProtocol {
                                             .getBytes(StandardCharsets.ISO_8859_1));
 
             final StringBuilder protocols = new StringBuilder(response.protocol().toString());
+            String cipherSuite = null;
             final Handshake handshake = connection.handshake();
             if (handshake != null) {
                 protocols.append(',').append(handshake.tlsVersion());
-                protocols.append(',').append(handshake.cipherSuite());
+                cipherSuite = handshake.cipherSuite().toString();
             }
 
             // returns a modified version of the response
@@ -686,6 +687,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
                     .header(ProtocolResponse.RESPONSE_IP_KEY, ipAddress)
                     .header(ProtocolResponse.REQUEST_TIME_KEY, Long.toString(startFetchTime))
                     .header(ProtocolResponse.PROTOCOL_VERSIONS_KEY, protocols.toString())
+                    .header(ProtocolResponse.CIPHER_SUITES_KEY, cipherSuite)
                     .build();
         }
     }

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -65,6 +65,7 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.Route;
+import okhttp3.TlsVersion;
 import okhttp3.brotli.Brotli;
 import okhttp3.zstd.Zstd;
 import okio.BufferedSource;
@@ -820,13 +821,37 @@ public class HttpProtocol extends AbstractHttpProtocol {
 
     static class HTTPHeadersInterceptor implements Interceptor {
 
-        private String getNormalizedProtocolName(Protocol protocol) {
+        private static String getNormalizedProtocolName(Protocol protocol) {
             String name = protocol.toString().toUpperCase(Locale.ROOT);
             if ("H2".equals(name)) {
                 // back-ward compatible protocol version name
                 name = "HTTP/2";
             }
             return name;
+        }
+
+        /**
+         * Maps a {@link TlsVersion} to the protocol identifier used in the <code>WARC-Protocol
+         * </code> header, see the <a
+         * href="https://github.com/iipc/warc-specifications/issues/42">WARC field proposal</a>. The
+         * enum names of {@link TlsVersion} (e.g. <code>TLS_1_3</code>) are not part of the
+         * registered values (e.g. <code>tls/1.3</code>).
+         */
+        private static String getProtocolIdentifier(TlsVersion tlsVersion) {
+            switch (tlsVersion) {
+                case SSL_3_0:
+                    return "ssl/3.0";
+                case TLS_1_0:
+                    return "tls/1.0";
+                case TLS_1_1:
+                    return "tls/1.1";
+                case TLS_1_2:
+                    return "tls/1.2";
+                case TLS_1_3:
+                    return "tls/1.3";
+                default:
+                    return tlsVersion.javaName().toLowerCase(Locale.ROOT);
+            }
         }
 
         @NotNull
@@ -904,27 +929,33 @@ public class HttpProtocol extends AbstractHttpProtocol {
                                             .toString()
                                             .getBytes(StandardCharsets.ISO_8859_1));
 
+            Response.Builder respBuilder =
+                    response.newBuilder()
+                            .header(
+                                    ProtocolResponse.REQUEST_HEADERS_KEY,
+                                    new String(encodedBytesRequest, StandardCharsets.ISO_8859_1))
+                            .header(
+                                    ProtocolResponse.RESPONSE_HEADERS_KEY,
+                                    new String(encodedBytesResponse, StandardCharsets.ISO_8859_1))
+                            .header(ProtocolResponse.RESPONSE_IP_KEY, ipAddress)
+                            .header(
+                                    ProtocolResponse.REQUEST_TIME_KEY,
+                                    Long.toString(startFetchTime));
+
             final StringBuilder protocols = new StringBuilder(response.protocol().toString());
             String cipherSuite = null;
             final Handshake handshake = connection.handshake();
             if (handshake != null) {
-                protocols.append(',').append(handshake.tlsVersion());
+                protocols.append(',').append(getProtocolIdentifier(handshake.tlsVersion()));
                 cipherSuite = handshake.cipherSuite().toString();
+                respBuilder = respBuilder.header(ProtocolResponse.CIPHER_SUITE_KEY, cipherSuite);
             }
+            respBuilder =
+                    respBuilder.header(
+                            ProtocolResponse.PROTOCOL_VERSIONS_KEY, protocols.toString());
 
             // returns a modified version of the response
-            return response.newBuilder()
-                    .header(
-                            ProtocolResponse.REQUEST_HEADERS_KEY,
-                            new String(encodedBytesRequest, StandardCharsets.ISO_8859_1))
-                    .header(
-                            ProtocolResponse.RESPONSE_HEADERS_KEY,
-                            new String(encodedBytesResponse, StandardCharsets.ISO_8859_1))
-                    .header(ProtocolResponse.RESPONSE_IP_KEY, ipAddress)
-                    .header(ProtocolResponse.REQUEST_TIME_KEY, Long.toString(startFetchTime))
-                    .header(ProtocolResponse.PROTOCOL_VERSIONS_KEY, protocols.toString())
-                    .header(ProtocolResponse.CIPHER_SUITES_KEY, cipherSuite)
-                    .build();
+            return respBuilder.build();
         }
     }
 

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -905,10 +905,11 @@ public class HttpProtocol extends AbstractHttpProtocol {
                                             .getBytes(StandardCharsets.ISO_8859_1));
 
             final StringBuilder protocols = new StringBuilder(response.protocol().toString());
+            String cipherSuite = null;
             final Handshake handshake = connection.handshake();
             if (handshake != null) {
                 protocols.append(',').append(handshake.tlsVersion());
-                protocols.append(',').append(handshake.cipherSuite());
+                cipherSuite = handshake.cipherSuite().toString();
             }
 
             // returns a modified version of the response
@@ -922,6 +923,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
                     .header(ProtocolResponse.RESPONSE_IP_KEY, ipAddress)
                     .header(ProtocolResponse.REQUEST_TIME_KEY, Long.toString(startFetchTime))
                     .header(ProtocolResponse.PROTOCOL_VERSIONS_KEY, protocols.toString())
+                    .header(ProtocolResponse.CIPHER_SUITES_KEY, cipherSuite)
                     .build();
         }
     }

--- a/core/src/test/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocolHeadersTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocolHeadersTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.protocol.okhttp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.storm.Config;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.protocol.AbstractProtocolTest;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.junit.jupiter.api.Test;
+
+/** Tests the protocol metadata collected by the response interceptor. */
+class HttpProtocolHeadersTest extends AbstractProtocolTest {
+
+    /**
+     * Over an unencrypted connection there is no handshake, hence no TLS version and no cipher
+     * suite. The cipher suite header must be skipped entirely: OkHttp's {@code
+     * Response.Builder.header(...)} does not accept a null value.
+     */
+    @Test
+    void plainHttpRequestStoresProtocolVersionButNoCipherSuite() throws Exception {
+        HttpProtocol protocol = new HttpProtocol();
+        Config conf = protocolConfig();
+        conf.put("http.store.headers", true);
+        protocol.configure(conf);
+
+        ProtocolResponse response =
+                protocol.getProtocolOutput("http://localhost:" + HTTP_PORT, Metadata.empty);
+
+        assertEquals(200, response.getStatusCode());
+        Metadata metadata = response.getMetadata();
+        assertEquals(
+                "http/1.1",
+                metadata.getFirstValue(ProtocolResponse.PROTOCOL_VERSIONS_KEY),
+                "The protocol version is expected to be stored for plain HTTP requests");
+        assertNull(
+                metadata.getFirstValue(ProtocolResponse.CIPHER_SUITE_KEY),
+                "No cipher suite is expected without a TLS handshake");
+    }
+
+    private Config protocolConfig() {
+        Config conf = new Config();
+        conf.put("http.agent.name", "test");
+        conf.put("http.agent.version", "1.0");
+        conf.put("http.agent.description", "test");
+        conf.put("http.agent.url", "http://test.example.com");
+        conf.put("http.agent.email", "test@example.com");
+        return conf;
+    }
+}

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
@@ -468,7 +468,14 @@ public class WARCRecordFormat implements RecordFormat {
                 metadata.getFirstValue(
                         ProtocolResponse.PROTOCOL_VERSIONS_KEY, this.protocolMDprefix);
         if (protocolVersions != null) {
-            buffer.append("WARC-Protocol: ").append(protocolVersions).append(CRLF);
+            for (String val : StringUtils.split(protocolVersions, ',')) {
+                buffer.append("WARC-Protocol: ").append(val).append(CRLF);
+            }
+        }
+        final String cipherSuites =
+                metadata.getFirstValue(ProtocolResponse.CIPHER_SUITES_KEY, this.protocolMDprefix);
+        if (cipherSuites != null) {
+            buffer.append("WARC-Cipher-Suite: ").append(cipherSuites).append(CRLF);
         }
 
         buffer.append("WARC-Payload-Digest").append(": ").append(payloadDigest).append(CRLF);

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
@@ -616,7 +616,14 @@ public class WARCRecordFormat implements RecordFormat {
                 metadata.getFirstValue(
                         ProtocolResponse.PROTOCOL_VERSIONS_KEY, this.protocolMDprefix);
         if (protocolVersions != null) {
-            buffer.append("WARC-Protocol: ").append(protocolVersions).append(CRLF);
+            for (String val : StringUtils.split(protocolVersions, ',')) {
+                buffer.append("WARC-Protocol: ").append(val).append(CRLF);
+            }
+        }
+        final String cipherSuites =
+                metadata.getFirstValue(ProtocolResponse.CIPHER_SUITES_KEY, this.protocolMDprefix);
+        if (cipherSuites != null) {
+            buffer.append("WARC-Cipher-Suite: ").append(cipherSuites).append(CRLF);
         }
 
         buffer.append("WARC-Payload-Digest").append(": ").append(payloadDigest).append(CRLF);

--- a/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
+++ b/external/warc/src/main/java/org/apache/stormcrawler/warc/WARCRecordFormat.java
@@ -616,12 +616,12 @@ public class WARCRecordFormat implements RecordFormat {
                 metadata.getFirstValue(
                         ProtocolResponse.PROTOCOL_VERSIONS_KEY, this.protocolMDprefix);
         if (protocolVersions != null) {
-            for (String val : StringUtils.split(protocolVersions, ',')) {
-                buffer.append("WARC-Protocol: ").append(val).append(CRLF);
+            for (String protocolVersion : StringUtils.split(protocolVersions, ',')) {
+                buffer.append("WARC-Protocol: ").append(protocolVersion.trim()).append(CRLF);
             }
         }
         final String cipherSuites =
-                metadata.getFirstValue(ProtocolResponse.CIPHER_SUITES_KEY, this.protocolMDprefix);
+                metadata.getFirstValue(ProtocolResponse.CIPHER_SUITE_KEY, this.protocolMDprefix);
         if (cipherSuites != null) {
             buffer.append("WARC-Cipher-Suite: ").append(cipherSuites).append(CRLF);
         }

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
@@ -130,6 +130,13 @@ class WARCHdfsBoltTest {
         assertTrue(
                 response.headers().first("WARC-Protocol").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+        assertEquals(
+                2,
+                response.headers().all("WARC-Protocol").size(),
+                "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+        assertTrue(
+                response.headers().first("WARC-Cipher-Suite").isPresent(),
+                "WARC response record is expected to include WARC header \"WARC-Cipher-Suite\"");
         assertTrue(
                 response.headers().first("WARC-IP-Address").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-IP-Address\"");
@@ -211,7 +218,9 @@ class WARCHdfsBoltTest {
                         + "Connection: close\r\n\r\n");
         metadata.addValue(
                 protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
-                httpVersionString + ",TLS_1_3,TLS_AES_256_GCM_SHA384");
+                httpVersionString + ",TLS_1_3");
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.CIPHER_SUITES_KEY, "TLS_AES_256_GCM_SHA384");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
@@ -130,6 +130,13 @@ class WARCHdfsBoltTest {
         assertTrue(
                 response.headers().first("WARC-Protocol").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+        assertEquals(
+                2,
+                response.headers().all("WARC-Protocol").size(),
+                "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+        assertTrue(
+                response.headers().first("WARC-Cipher-Suite").isPresent(),
+                "WARC response record is expected to include WARC header \"WARC-Cipher-Suite\"");
         assertTrue(
                 response.headers().first("WARC-IP-Address").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-IP-Address\"");
@@ -241,7 +248,9 @@ class WARCHdfsBoltTest {
                         + "Connection: close\r\n\r\n");
         metadata.addValue(
                 protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
-                httpVersionString + ",TLS_1_3,TLS_AES_256_GCM_SHA384");
+                httpVersionString + ",TLS_1_3");
+        metadata.addValue(
+                protocolMDprefix + ProtocolResponse.CIPHER_SUITES_KEY, "TLS_AES_256_GCM_SHA384");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCHdfsBoltTest.java
@@ -105,9 +105,10 @@ class WARCHdfsBoltTest {
         assertEquals("response", records.get(2).type());
         WarcResponse response = (WarcResponse) records.get(2);
         assertEquals(MessageVersion.HTTP_1_1, response.http().version());
-        assertTrue(
-                response.headers().first("WARC-Protocol").isPresent(),
-                "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+        assertEquals(
+                List.of("HTTP/1.1", "tls/1.3"),
+                response.headers().all("WARC-Protocol"),
+                "WARC response record is expected to repeat the WARC header \"WARC-Protocol\" for every protocol layer");
         assertTrue(
                 response.headers().first("WARC-IP-Address").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-IP-Address\"");
@@ -131,9 +132,9 @@ class WARCHdfsBoltTest {
                 response.headers().first("WARC-Protocol").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-Protocol\"");
         assertEquals(
-                2,
-                response.headers().all("WARC-Protocol").size(),
-                "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+                List.of("HTTP/2", "tls/1.3"),
+                response.headers().all("WARC-Protocol"),
+                "WARC response record is expected to repeat the WARC header \"WARC-Protocol\" for every protocol layer");
         assertTrue(
                 response.headers().first("WARC-Cipher-Suite").isPresent(),
                 "WARC response record is expected to include WARC header \"WARC-Cipher-Suite\"");
@@ -248,9 +249,9 @@ class WARCHdfsBoltTest {
                         + "Connection: close\r\n\r\n");
         metadata.addValue(
                 protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
-                httpVersionString + ",TLS_1_3");
+                httpVersionString + ",tls/1.3");
         metadata.addValue(
-                protocolMDprefix + ProtocolResponse.CIPHER_SUITES_KEY, "TLS_AES_256_GCM_SHA384");
+                protocolMDprefix + ProtocolResponse.CIPHER_SUITE_KEY, "TLS_AES_256_GCM_SHA384");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
@@ -225,9 +225,9 @@ class WARCRecordFormatTest {
                         + "Content-Encoding: gzip\r\n"
                         + "Content-Length: 26\r\n"
                         + "Connection: close");
+        metadata.addValue(protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY, "h2,TLS_1_3");
         metadata.addValue(
-                protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
-                "h2,TLS_1_3,TLS_AES_256_GCM_SHA384");
+                protocolMDprefix + ProtocolResponse.CIPHER_SUITES_KEY, "TLS_AES_256_GCM_SHA384");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);
@@ -246,8 +246,14 @@ class WARCRecordFormatTest {
                 statusLine.matches("^HTTP/1\\.[01] .*"),
                 "WARC response record: HTTP status line must start with HTTP/1.1 or HTTP/1.0");
         assertTrue(
-                headersPayload[0].contains("\r\nWARC-Protocol: "),
-                "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+                headersPayload[0].contains("\r\nWARC-Protocol: h2\r\n"),
+                "WARC response record is expected to include a WARC header \"WARC-Protocol: h2\"");
+        assertTrue(
+                headersPayload[0].contains("\r\nWARC-Protocol: TLS_1_3\r\n"),
+                "WARC response record is expected to include a WARC header \"WARC-Protocol: TLS_1_3\"");
+        assertTrue(
+                headersPayload[0].contains("\r\nWARC-Cipher-Suite: "),
+                "WARC response record is expected to include WARC header \"WARC-Cipher-Suite\"");
         assertTrue(
                 headersPayload[0].contains("\r\nWARC-IP-Address: "),
                 "WARC response record is expected to include WARC header \"WARC-IP-Address\"");

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
@@ -252,9 +252,9 @@ class WARCRecordFormatTest {
                         + "Content-Encoding: gzip\r\n"
                         + "Content-Length: 26\r\n"
                         + "Connection: close");
+        metadata.addValue(protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY, "h2,TLS_1_3");
         metadata.addValue(
-                protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY,
-                "h2,TLS_1_3,TLS_AES_256_GCM_SHA384");
+                protocolMDprefix + ProtocolResponse.CIPHER_SUITES_KEY, "TLS_AES_256_GCM_SHA384");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);
@@ -273,8 +273,14 @@ class WARCRecordFormatTest {
                 statusLine.matches("^HTTP/1\\.[01] .*"),
                 "WARC response record: HTTP status line must start with HTTP/1.1 or HTTP/1.0");
         assertTrue(
-                headersPayload[0].contains("\r\nWARC-Protocol: "),
-                "WARC response record is expected to include WARC header \"WARC-Protocol\"");
+                headersPayload[0].contains("\r\nWARC-Protocol: h2\r\n"),
+                "WARC response record is expected to include a WARC header \"WARC-Protocol: h2\"");
+        assertTrue(
+                headersPayload[0].contains("\r\nWARC-Protocol: TLS_1_3\r\n"),
+                "WARC response record is expected to include a WARC header \"WARC-Protocol: TLS_1_3\"");
+        assertTrue(
+                headersPayload[0].contains("\r\nWARC-Cipher-Suite: "),
+                "WARC response record is expected to include WARC header \"WARC-Cipher-Suite\"");
         assertTrue(
                 headersPayload[0].contains("\r\nWARC-IP-Address: "),
                 "WARC response record is expected to include WARC header \"WARC-IP-Address\"");

--- a/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
+++ b/external/warc/src/test/java/org/apache/stormcrawler/warc/WARCRecordFormatTest.java
@@ -252,9 +252,9 @@ class WARCRecordFormatTest {
                         + "Content-Encoding: gzip\r\n"
                         + "Content-Length: 26\r\n"
                         + "Connection: close");
-        metadata.addValue(protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY, "h2,TLS_1_3");
+        metadata.addValue(protocolMDprefix + ProtocolResponse.PROTOCOL_VERSIONS_KEY, "h2,tls/1.3");
         metadata.addValue(
-                protocolMDprefix + ProtocolResponse.CIPHER_SUITES_KEY, "TLS_AES_256_GCM_SHA384");
+                protocolMDprefix + ProtocolResponse.CIPHER_SUITE_KEY, "TLS_AES_256_GCM_SHA384");
         metadata.addValue(protocolMDprefix + ProtocolResponse.RESPONSE_IP_KEY, "123.123.123.123");
         Tuple tuple = mock(Tuple.class);
         when(tuple.getBinaryByField("content")).thenReturn(content);
@@ -276,8 +276,8 @@ class WARCRecordFormatTest {
                 headersPayload[0].contains("\r\nWARC-Protocol: h2\r\n"),
                 "WARC response record is expected to include a WARC header \"WARC-Protocol: h2\"");
         assertTrue(
-                headersPayload[0].contains("\r\nWARC-Protocol: TLS_1_3\r\n"),
-                "WARC response record is expected to include a WARC header \"WARC-Protocol: TLS_1_3\"");
+                headersPayload[0].contains("\r\nWARC-Protocol: tls/1.3\r\n"),
+                "WARC response record is expected to include a WARC header \"WARC-Protocol: tls/1.3\"");
         assertTrue(
                 headersPayload[0].contains("\r\nWARC-Cipher-Suite: "),
                 "WARC response record is expected to include WARC header \"WARC-Cipher-Suite\"");


### PR DESCRIPTION
This PR addresses #1998.

OkHttp protocol:
- add protocol response header key `_cipher_suites_` to hold the SSL/TLS Cipher suite separate from `_protocol_versions_`.

WARC writer:
- add WARC header `WARC-Cipher-Suite`
- split multiple values in `WARC-Protocol` header and repeat header

Example WARC header with this change applied:
```
WARC/1.0
WARC-Record-ID: <urn:uuid:64d3f1a3-2293-4581-b676-a4d715b65ebc>
Content-Length: 30510
WARC-Date: 2026-07-29T17:20:01Z
WARC-Type: response
WARC-IP-Address: 2620:cb:2000::1
WARC-Target-URI: https://commoncrawl.org/blog/common-crawl-foundation-at-lrec-2026
Content-Type: application/http; msgtype=response
WARC-Protocol: h2
WARC-Protocol: TLS_1_3
WARC-Cipher-Suite: TLS_AES_128_GCM_SHA256
WARC-Payload-Digest: sha1:72ZYLF3J57X4GOO6UNSPQHE366QPTWVL
WARC-Block-Digest: sha1:M34FZULWWPMGUNTPJZLUGUPQ7TE5G5JS

HTTP/1.1 200 
date: Wed, 29 Jul 2026 17:20:01 GMT
...
```