### PR TITLE
bugfix set Java 25 for snapshots workflow

### DIFF
--- a/.github/workflows/snapshots.yaml
+++ b/.github/workflows/snapshots.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
       - id: extract_version
         name: Extract project version
         shell: bash


### PR DESCRIPTION
the snapshots have been failing since moving to Java 25
https://github.com/apache/stormcrawler/actions/workflows/snapshots.yaml