### PR TITLE
Honour ignoreOutsideDomain when set on its own in HostURLFilter

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/filtering/host/HostURLFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/host/HostURLFilter.java
@@ -62,7 +62,7 @@ public class HostURLFilter extends URLFilter {
         // always the same
         if (!ignoreOutsideHost) {
             JsonNode filterByDomainNode = filterParams.get("ignoreOutsideDomain");
-            if (filterByHostNode == null) {
+            if (filterByDomainNode == null) {
                 ignoreOutsideDomain = false;
             } else {
                 ignoreOutsideDomain = filterByDomainNode.asBoolean(false);

--- a/core/src/test/java/org/apache/stormcrawler/filtering/HostURLFilterTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/HostURLFilterTest.java
@@ -36,10 +36,14 @@ import org.junit.jupiter.api.Test;
 class HostURLFilterTest {
 
     private HostURLFilter createFilter(boolean ignoreOutsideHost, boolean ignoreOutsideDomain) {
-        HostURLFilter filter = new HostURLFilter();
         ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
         filterParams.put("ignoreOutsideHost", Boolean.valueOf(ignoreOutsideHost));
         filterParams.put("ignoreOutsideDomain", Boolean.valueOf(ignoreOutsideDomain));
+        return createFilter(filterParams);
+    }
+
+    private HostURLFilter createFilter(ObjectNode filterParams) {
+        HostURLFilter filter = new HostURLFilter();
         Map<String, Object> conf = new HashMap<>();
         filter.configure(conf, filterParams);
         return filter;
@@ -107,5 +111,36 @@ class HostURLFilterTest {
         filterResult =
                 allAllowed.filter(sourceURL, metadata, "http://sub.sourcedomain.com/index.html");
         Assertions.assertEquals("http://sub.sourcedomain.com/index.html", filterResult);
+    }
+
+    /** The two modes are independent, so ignoreOutsideDomain must be honoured on its own. */
+    @Test
+    void testWithinDomainWithoutHostParameter() throws MalformedURLException {
+        ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
+        filterParams.put("ignoreOutsideDomain", Boolean.TRUE);
+        HostURLFilter withinDomain = createFilter(filterParams);
+        URL sourceURL = URLUtil.toURL("http://www.sourcedomain.com/index.html");
+        Metadata metadata = new Metadata();
+        String filterResult =
+                withinDomain.filter(sourceURL, metadata, "http://sub.sourcedomain.com/index.html");
+        Assertions.assertEquals("http://sub.sourcedomain.com/index.html", filterResult);
+        filterResult =
+                withinDomain.filter(sourceURL, metadata, "http://www.anotherDomain.com/index.html");
+        Assertions.assertNull(filterResult);
+    }
+
+    /**
+     * A configuration which sets ignoreOutsideHost only must not fail on the missing domain key.
+     */
+    @Test
+    void testHostParameterWithoutDomainParameter() throws MalformedURLException {
+        ObjectNode filterParams = new ObjectNode(JsonNodeFactory.instance);
+        filterParams.put("ignoreOutsideHost", Boolean.FALSE);
+        HostURLFilter allAllowed = createFilter(filterParams);
+        URL sourceURL = URLUtil.toURL("http://www.sourcedomain.com/index.html");
+        Metadata metadata = new Metadata();
+        String filterResult =
+                allAllowed.filter(sourceURL, metadata, "http://www.anotherDomain.com/index.html");
+        Assertions.assertEquals("http://www.anotherDomain.com/index.html", filterResult);
     }
 }


### PR DESCRIPTION
`HostURLFilter.configure()` read the `ignoreOutsideDomain` parameter but tested the `ignoreOutsideHost` node for null. A configuration naming only `ignoreOutsideDomain` was silently discarded and the filter let every URL through; one naming only `ignoreOutsideHost: false` threw a `NullPointerException` at topology startup. `ignoreOutsideHost: true` was never affected, as it short-circuits before the domain parameter is read. Each parameter is now tested on its own.

Topologies setting only `ignoreOutsideDomain: true` will start restricting outlinks to the source domain, as configured. Configurations setting both keys, including all three archetypes, are unaffected.

### For all changes

- [ ] Is there a issue associated with this PR? Is it referenced in the commit message? - no issue

- [ ] Does your PR title start with `#XXXX` where `XXXX` is the issue number you are trying to resolve? - no issue

- [x] Has your PR been rebased against the latest commit within the target branch (typically main)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Is the code properly formatted with `mvn git-code-format:format-code -Dgcf.globPattern="**/*" -Dskip.format.code=false`?

### For code changes

- [ ] Have you ensured that the full suite of tests is executed via `mvn clean verify`? - `core` module tests only (348 run, all green)
- [x] Have you written or updated unit tests to verify your changes? - two new cases in `HostURLFilterTest`, both fail without the fix
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)? - no new dependencies
- [x] If applicable, have you updated the LICENSE file, including the main LICENSE file? - n/a
- [x] If applicable, have you updated the NOTICE file, including the main NOTICE file? - n/a

