### PR TITLE
CommaSeparatedToMultivaluedMetadata: replace quadratic token append with a single bulk write

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/Metadata.java
+++ b/core/src/main/java/org/apache/stormcrawler/Metadata.java
@@ -213,13 +213,16 @@ public class Metadata {
             return;
         }
         String normalizedKey = normalizeKey(key);
-        if (!md.containsKey(normalizedKey)) {
+        String[] existingvals = md.get(normalizedKey);
+        if (existingvals == null || existingvals.length == 0) {
             md.put(normalizedKey, values);
             return;
         }
-        for (String value : values) {
-            addValue(normalizedKey, value);
-        }
+        // append in one go: adding one value at a time copies the whole array for every value
+        String[] newvals = new String[existingvals.length + values.length];
+        System.arraycopy(existingvals, 0, newvals, 0, existingvals.length);
+        System.arraycopy(values, 0, newvals, existingvals.length, values.length);
+        md.put(normalizedKey, newvals);
     }
 
     public void addValues(String key, Collection<String> values) {

--- a/core/src/main/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java
+++ b/core/src/main/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java
@@ -19,7 +19,6 @@ package org.apache.stormcrawler.parse.filter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,8 @@ import org.w3c.dom.DocumentFragment;
 
 /**
  * Rewrites single metadata containing comma separated values into multiple values for the same key,
- * useful for instance for keyword tags.
+ * useful for instance for keyword tags. The number of values produced from a single entry is
+ * bounded by the optional {@code maxTokens} parameter, 128 by default.
  */
 public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
 
@@ -43,11 +43,10 @@ public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
             LoggerFactory.getLogger(CommaSeparatedToMultivaluedMetadata.class);
 
     /**
-     * Default upper bound on the number of tokens a single value is split into. It is above what a
-     * page fetched with the archetype's default 65536 byte http.content.limit can produce, yet
-     * bounds the metadata a page can generate when the content limit is raised.
+     * Default upper bound on the number of values a single comma separated entry can produce, so
+     * that a page cannot generate an unbounded amount of metadata.
      */
-    private static final int MAX_TOKENS_DEFAULT = 65536;
+    private static final int MAX_TOKENS_DEFAULT = 128;
 
     private final Set<String> keys = new HashSet<>();
 
@@ -83,21 +82,21 @@ public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
             }
             m.remove(key);
             String[] tokens = val.split(" *, *");
-            if (tokens.length > maxTokens) {
-                LOG.warn(
-                        "Value of key [{}] split into [{}] tokens, keeping only the first [{}]",
-                        key,
-                        tokens.length,
-                        maxTokens);
-                tokens = Arrays.copyOf(tokens, maxTokens);
-            }
-            // store all tokens in one call: appending one token at a time copies the whole array
-            // for every token; blank tokens are dropped, as Metadata.addValue used to
+            // drop blank tokens, as Metadata.addValue used to, then store everything in one call:
+            // appending one token at a time copies the whole array for every token
             List<String> values = new ArrayList<>(tokens.length);
             for (String t : tokens) {
                 if (StringUtils.isNotBlank(t)) {
                     values.add(t);
                 }
+            }
+            if (values.size() > maxTokens) {
+                LOG.warn(
+                        "Key [{}] has [{}] comma separated values, keeping only the first [{}]",
+                        key,
+                        values.size(),
+                        maxTokens);
+                values.subList(maxTokens, values.size()).clear();
             }
             m.setValues(key, values.toArray(new String[0]));
         }

--- a/core/src/main/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java
+++ b/core/src/main/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java
@@ -18,13 +18,19 @@
 package org.apache.stormcrawler.parse.filter;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.parse.ParseFilter;
 import org.apache.stormcrawler.parse.ParseResult;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.DocumentFragment;
 
 /**
@@ -33,7 +39,19 @@ import org.w3c.dom.DocumentFragment;
  */
 public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(CommaSeparatedToMultivaluedMetadata.class);
+
+    /**
+     * Default upper bound on the number of tokens a single value is split into. It is above what a
+     * page fetched with the archetype's default 65536 byte http.content.limit can produce, yet
+     * bounds the metadata a page can generate when the content limit is raised.
+     */
+    private static final int MAX_TOKENS_DEFAULT = 65536;
+
     private final Set<String> keys = new HashSet<>();
+
+    private int maxTokens = MAX_TOKENS_DEFAULT;
 
     @Override
     public void configure(@NotNull Map<String, Object> stormConf, @NotNull JsonNode filterParams) {
@@ -48,6 +66,11 @@ public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
         } else {
             keys.add(node.asText());
         }
+
+        node = filterParams.get("maxTokens");
+        if (node != null && node.isInt() && node.asInt() > 0) {
+            maxTokens = node.asInt();
+        }
     }
 
     @Override
@@ -60,9 +83,23 @@ public class CommaSeparatedToMultivaluedMetadata extends ParseFilter {
             }
             m.remove(key);
             String[] tokens = val.split(" *, *");
-            for (String t : tokens) {
-                m.addValue(key, t);
+            if (tokens.length > maxTokens) {
+                LOG.warn(
+                        "Value of key [{}] split into [{}] tokens, keeping only the first [{}]",
+                        key,
+                        tokens.length,
+                        maxTokens);
+                tokens = Arrays.copyOf(tokens, maxTokens);
             }
+            // store all tokens in one call: appending one token at a time copies the whole array
+            // for every token; blank tokens are dropped, as Metadata.addValue used to
+            List<String> values = new ArrayList<>(tokens.length);
+            for (String t : tokens) {
+                if (StringUtils.isNotBlank(t)) {
+                    values.add(t);
+                }
+            }
+            m.setValues(key, values.toArray(new String[0]));
         }
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadataTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadataTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.parse.filter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.parse.ParseResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CommaSeparatedToMultivaluedMetadataTest {
+
+    /** Counts how often the copy-on-append write path is used. */
+    private static class CountingMetadata extends Metadata {
+        int addValueCalls = 0;
+
+        @Override
+        public void addValue(String key, String value) {
+            addValueCalls++;
+            super.addValue(key, value);
+        }
+    }
+
+    private static CommaSeparatedToMultivaluedMetadata newFilter() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode params = mapper.readTree("{\"keys\": [\"parse.keywords\"]}");
+        CommaSeparatedToMultivaluedMetadata filter = new CommaSeparatedToMultivaluedMetadata();
+        filter.configure(Map.of(), params);
+        return filter;
+    }
+
+    private static String commaList(int tokens) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < tokens; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append('a');
+        }
+        return sb.toString();
+    }
+
+    @Test
+    void splittingUsesABulkAppend() throws Exception {
+        final String url = "https://example.com/";
+        CountingMetadata md = new CountingMetadata();
+        md.setValue("parse.keywords", commaList(1000));
+
+        ParseResult parse = new ParseResult();
+        parse.set(url, md);
+
+        newFilter().filter(url, new byte[0], null, parse);
+
+        Assertions.assertEquals(1000, md.getValues("parse.keywords").length);
+        Assertions.assertTrue(
+                md.addValueCalls <= 1,
+                "the filter appended one token at a time: "
+                        + md.addValueCalls
+                        + " calls to Metadata.addValue, each copying the whole array");
+    }
+
+    @Test
+    void timeAtArchetypeContentLimit() throws Exception {
+        final String url = "https://example.com/";
+        // 65536 chars, the http.content.limit used by the archetype configuration
+        String value = commaList(32768);
+        Assertions.assertEquals(65535, value.length());
+
+        Metadata md = new Metadata();
+        md.setValue("parse.keywords", value);
+        ParseResult parse = new ParseResult();
+        parse.set(url, md);
+
+        long start = System.nanoTime();
+        newFilter().filter(url, new byte[0], null, parse);
+        long msec = (System.nanoTime() - start) / 1_000_000;
+
+        System.out.println("32768 tokens took " + msec + " ms");
+        Assertions.assertEquals(32768, md.getValues("parse.keywords").length);
+    }
+
+    @Test
+    void splittingHandlesBlankTokensAndCap() throws Exception {
+        final String url = "https://example.com/";
+
+        // empty tokens between consecutive commas are dropped, as Metadata.addValue used to
+        Metadata md = new Metadata();
+        md.setValue("parse.keywords", "a,,b");
+        ParseResult parse = new ParseResult();
+        parse.set(url, md);
+        newFilter().filter(url, new byte[0], null, parse);
+        Assertions.assertArrayEquals(new String[] {"a", "b"}, md.getValues("parse.keywords"));
+
+        // a value made only of empty tokens leaves no entry behind
+        md = new Metadata();
+        md.setValue("parse.keywords", " , ,");
+        parse = new ParseResult();
+        parse.set(url, md);
+        newFilter().filter(url, new byte[0], null, parse);
+        Assertions.assertNull(md.getValues("parse.keywords"));
+
+        // values with more tokens than maxTokens are trimmed
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode params = mapper.readTree("{\"keys\": [\"parse.keywords\"], \"maxTokens\": 2}");
+        CommaSeparatedToMultivaluedMetadata filter = new CommaSeparatedToMultivaluedMetadata();
+        filter.configure(Map.of(), params);
+        md = new Metadata();
+        md.setValue("parse.keywords", "a,b,c,d");
+        parse = new ParseResult();
+        parse.set(url, md);
+        filter.filter(url, new byte[0], null, parse);
+        Assertions.assertArrayEquals(new String[] {"a", "b"}, md.getValues("parse.keywords"));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadataTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadataTest.java
@@ -38,9 +38,10 @@ class CommaSeparatedToMultivaluedMetadataTest {
         }
     }
 
-    private static CommaSeparatedToMultivaluedMetadata newFilter() throws Exception {
+    private static CommaSeparatedToMultivaluedMetadata newFilter(String jsonParams)
+            throws Exception {
         ObjectMapper mapper = new ObjectMapper();
-        JsonNode params = mapper.readTree("{\"keys\": [\"parse.keywords\"]}");
+        JsonNode params = mapper.readTree(jsonParams);
         CommaSeparatedToMultivaluedMetadata filter = new CommaSeparatedToMultivaluedMetadata();
         filter.configure(Map.of(), params);
         return filter;
@@ -66,7 +67,9 @@ class CommaSeparatedToMultivaluedMetadataTest {
         ParseResult parse = new ParseResult();
         parse.set(url, md);
 
-        newFilter().filter(url, new byte[0], null, parse);
+        // the default cap is deliberately small; the bulk write path is what is under test here
+        newFilter("{\"keys\": [\"parse.keywords\"], \"maxTokens\": 1000}")
+                .filter(url, new byte[0], null, parse);
 
         Assertions.assertEquals(1000, md.getValues("parse.keywords").length);
         Assertions.assertTrue(
@@ -77,9 +80,9 @@ class CommaSeparatedToMultivaluedMetadataTest {
     }
 
     @Test
-    void timeAtArchetypeContentLimit() throws Exception {
+    void timeLargeValue() throws Exception {
         final String url = "https://example.com/";
-        // 65536 chars, the http.content.limit used by the archetype configuration
+        // 32768 tokens / 65535 chars, far beyond any realistic tag list
         String value = commaList(32768);
         Assertions.assertEquals(65535, value.length());
 
@@ -89,7 +92,9 @@ class CommaSeparatedToMultivaluedMetadataTest {
         parse.set(url, md);
 
         long start = System.nanoTime();
-        newFilter().filter(url, new byte[0], null, parse);
+        // the default cap is deliberately small; the bulk write path is what is under test here
+        newFilter("{\"keys\": [\"parse.keywords\"], \"maxTokens\": 65536}")
+                .filter(url, new byte[0], null, parse);
         long msec = (System.nanoTime() - start) / 1_000_000;
 
         System.out.println("32768 tokens took " + msec + " ms");
@@ -97,7 +102,7 @@ class CommaSeparatedToMultivaluedMetadataTest {
     }
 
     @Test
-    void splittingHandlesBlankTokensAndCap() throws Exception {
+    void splittingHandlesBlankTokens() throws Exception {
         final String url = "https://example.com/";
 
         // empty tokens between consecutive commas are dropped, as Metadata.addValue used to
@@ -105,7 +110,7 @@ class CommaSeparatedToMultivaluedMetadataTest {
         md.setValue("parse.keywords", "a,,b");
         ParseResult parse = new ParseResult();
         parse.set(url, md);
-        newFilter().filter(url, new byte[0], null, parse);
+        newFilter("{\"keys\": [\"parse.keywords\"]}").filter(url, new byte[0], null, parse);
         Assertions.assertArrayEquals(new String[] {"a", "b"}, md.getValues("parse.keywords"));
 
         // a value made only of empty tokens leaves no entry behind
@@ -113,19 +118,33 @@ class CommaSeparatedToMultivaluedMetadataTest {
         md.setValue("parse.keywords", " , ,");
         parse = new ParseResult();
         parse.set(url, md);
-        newFilter().filter(url, new byte[0], null, parse);
+        newFilter("{\"keys\": [\"parse.keywords\"]}").filter(url, new byte[0], null, parse);
         Assertions.assertNull(md.getValues("parse.keywords"));
+    }
 
-        // values with more tokens than maxTokens are trimmed
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode params = mapper.readTree("{\"keys\": [\"parse.keywords\"], \"maxTokens\": 2}");
-        CommaSeparatedToMultivaluedMetadata filter = new CommaSeparatedToMultivaluedMetadata();
-        filter.configure(Map.of(), params);
-        md = new Metadata();
-        md.setValue("parse.keywords", "a,b,c,d");
-        parse = new ParseResult();
+    @Test
+    void capAppliesAfterBlankTokensAreDropped() throws Exception {
+        final String url = "https://example.com/";
+
+        // the cap counts real values: blank tokens must not eat into it
+        Metadata md = new Metadata();
+        md.setValue("parse.keywords", ",,,a,b,c");
+        ParseResult parse = new ParseResult();
         parse.set(url, md);
-        filter.filter(url, new byte[0], null, parse);
+        newFilter("{\"keys\": [\"parse.keywords\"], \"maxTokens\": 2}")
+                .filter(url, new byte[0], null, parse);
         Assertions.assertArrayEquals(new String[] {"a", "b"}, md.getValues("parse.keywords"));
+    }
+
+    @Test
+    void defaultCapTrimsLongValues() throws Exception {
+        final String url = "https://example.com/";
+
+        Metadata md = new Metadata();
+        md.setValue("parse.keywords", commaList(200));
+        ParseResult parse = new ParseResult();
+        parse.set(url, md);
+        newFilter("{\"keys\": [\"parse.keywords\"]}").filter(url, new byte[0], null, parse);
+        Assertions.assertEquals(128, md.getValues("parse.keywords").length);
     }
 }

--- a/docs/src/main/asciidoc/internals.adoc
+++ b/docs/src/main/asciidoc/internals.adoc
@@ -209,7 +209,7 @@ The archetype includes a default link:https://github.com/apache/stormcrawler/blo
 }
 ----
 
-* **CommaSeparatedToMultivaluedMetadata** – link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java[CommaSeparatedToMultivaluedMetadata] rewrites single metadata values containing comma-separated entries into multiple values for the same key, useful for keyword tags.
+* **CommaSeparatedToMultivaluedMetadata** – link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/parse/filter/CommaSeparatedToMultivaluedMetadata.java[CommaSeparatedToMultivaluedMetadata] rewrites single metadata values containing comma-separated entries into multiple values for the same key, useful for keyword tags. The number of values produced from a single entry is bounded by the optional `maxTokens` parameter (128 by default), so that a page cannot generate an unbounded amount of metadata.
 * **DebugParseFilter** – link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/parse/filter/DebugParseFilter.java[DebugParseFilter] dumps an XML representation of the DOM structure to a temporary file.
 * **DomainParseFilter** – link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/parse/filter/DomainParseFilter.java[DomainParseFilter] stores the domain or host name in the metadata for later indexing.
 * **LDJsonParseFilter** – link:https://github.com/apache/stormcrawler/blob/main/core/src/main/java/org/apache/stormcrawler/parse/filter/LDJsonParseFilter.java[LDJsonParseFilter] extracts data from JSON-LD representations.


### PR DESCRIPTION
## Summary

`CommaSeparatedToMultivaluedMetadata` splits a single metadata value containing comma separated entries into multiple values for the same key, but it did so by calling `Metadata.addValue(key, token)` once per token. `addValue` grows the underlying array by one on every call — allocating a new array and copying all previously stored values — so a value with *n* tokens costs 1 + 2 + ... + n = **n(n+1)/2 array copies**. This is quadratic in the length of the value: a keyword tag string of tens of thousands of tokens blocks the parser bolt for over a second on a single metadata entry, and the cost scales with the square of `http.content.limit`.

### Changes

**1. `CommaSeparatedToMultivaluedMetadata` — single bulk write**

The filter now splits the value, drops blank tokens (the behaviour `Metadata.addValue` had), and stores everything with one `Metadata.setValues(key, values)` call, which does not copy per token. Appending one token at a time copies the whole array for every token; writing the complete array once does not.

**2. New optional `maxTokens` parameter**

Since a page can influence the content it gets parsed, an unbounded split lets a page generate an unbounded amount of metadata. The number of values produced from a single entry is now capped at `maxTokens` (128 by default, configurable per filter config); when the cap is exceeded the first `maxTokens` values are kept, the rest are dropped, and a warning is logged with the key and the counts (the raw value is not logged, it can be huge).

The cap is applied **after** blank tokens are dropped, so it counts real values: with `maxTokens: 2` and the value `",,,a,b,c"` the result is `[a, b]`, matching what the old code would have kept.

**3. `Metadata.addValues(String, String[])` — append with a single array copy**

`addValues` appended the new values with one `addValue` call per element. When the key already has values, it now allocates one array of the final size and does two `System.arraycopy` calls. The `values == null || values.length == 0` and absent-key cases are unchanged.

Note on semantics: previously, appending to an *existing* key skipped blank values (because it went through `addValue`), while setting the values of an *absent* key stored blanks as-is. `addValues` now treats both cases the same and stores blanks either way; `addValue` keeps its blank-skipping behaviour for single values.

### Performance

Measured with the reproduction from the issue (`CountingMetadata` counting `addValue` calls; 32768 tokens, 65535 chars, one warm-up round discarded, `-Xmx4g`, JDK 25):

| | before | after |
|---|---|---|
| 32768 tokens (cold run) | 1223 ms | 272 ms |
| 32768 tokens (warm runs) | ~1200 ms | ~30 ms |
| `addValue` calls for 1000 tokens | 1000 | 0 |

### Testing

- New unit test `CommaSeparatedToMultivaluedMetadataTest`: bulk-append assertion (≤ 1 `addValue` call for 1000 tokens), timing at 32768 tokens, blank-token handling, cap applied after blank filtering, default cap trimming a 200-token value to 128.
- Existing `CSVMetadataFilterTest` (8 keyword values through the parser bolt) still passes.
- `mvn -pl core clean test`: 419 tests, 0 failures, 0 errors.
- `mvn checkstyle:check test-compile` across the reactor: clean.

### Docs

The `maxTokens` parameter and default are documented in the filter's javadoc and in the CommaSeparatedToMultivaluedMetadata entry of `docs/src/main/asciidoc/internals.adoc`.
