### PR TITLE
#2104 feat: implement MIME type whitelist filtering in ParserBolt for Tika

### DIFF
--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -531,7 +531,7 @@ See the link:https://github.com/apache/stormcrawler/tree/main/external/tika[tika
 |===
 | key | default value | description
 
-| parser.mimetype.whitelist | - | Regex list of allowed MIME types. If set, only matching types are parsed by the Tika ParserBolt.
+| parser.mimetype.whitelist | - | Regex list of allowed MIME types. If set, only matching types are parsed by the Tika ParserBolt. The pattern is matched against the byte-detected MIME type, not the server-declared HTTP `Content-Type` header.
 | parser.tika.config.file | tika-config.json | Name of the classpath resource holding the Tika configuration (JSON format since Tika 4).
 | parser.extract.embedded | false | Whether to parse embedded documents. Since Tika 4 embedded documents are no longer parsed unless this is set to `true`.
 |===

--- a/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
@@ -173,7 +173,9 @@ public class ParserBolt extends BaseRichBolt {
         // check that the mimetype is in the whitelist
         if (!mimeTypeWhiteList.isEmpty()) {
             boolean mt_match = false;
-            // see if a mimetype was detected already (e.g. by JSoupParserBolt)
+            // parse.Content-Type is assumed byte-detected (JSoupParserBolt uses Tika detection,
+            // not the raw server header). A custom upstream writing a header-copied value bypasses
+            // this check — that is a caller responsibility.
             String mimeType = metadata.getFirstValue("parse.Content-Type");
             if (mimeType == null) {
                 // parse.Content-Type is absent: detect from content bytes so that
@@ -188,6 +190,15 @@ public class ParserBolt extends BaseRichBolt {
                     // pass the header as a hint only — detect() weighs it but
                     // content bytes take precedence
                     detectionMd.set(org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
+                }
+                // pass the filename so detection matches what the parser dispatches on;
+                // without it, an ambiguous byte sequence (e.g. plain text with a .html
+                // extension) can resolve differently here than at parse time
+                try {
+                    URL _url = URLUtil.toURL(url);
+                    detectionMd.set(TikaCoreProperties.RESOURCE_NAME_KEY, _url.getFile());
+                } catch (MalformedURLException e1) {
+                    throw new IllegalStateException("Malformed URL", e1);
                 }
                 try {
                     mimeType = tika.detect(new ByteArrayInputStream(content), detectionMd);

--- a/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
@@ -187,12 +187,10 @@ public class ParserBolt extends BaseRichBolt {
                 if (StringUtils.isNotBlank(httpCTHint)) {
                     // pass the header as a hint only — detect() weighs it but
                     // content bytes take precedence
-                    detectionMd.set(
-                            org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
+                    detectionMd.set(org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
                 }
                 try {
-                    mimeType =
-                            tika.detect(new ByteArrayInputStream(content), detectionMd);
+                    mimeType = tika.detect(new ByteArrayInputStream(content), detectionMd);
                 } catch (IOException e) {
                     LOG.warn("Failed to detect MIME type for {}: {}", url, e.getMessage());
                 }

--- a/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
@@ -187,8 +187,9 @@ public class ParserBolt extends BaseRichBolt {
                 org.apache.tika.metadata.Metadata detectionMd =
                         new org.apache.tika.metadata.Metadata();
                 if (StringUtils.isNotBlank(httpCTHint)) {
-                    // pass the header as a hint only — detect() weighs it but
-                    // content bytes take precedence
+                    // the hint narrows the magic result: when bytes are unrecognised Tika
+                    // returns application/octet-stream and the hint specialises it, so the
+                    // effective type matches what AutoDetectParser dispatches on
                     detectionMd.set(org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
                 }
                 // pass the filename so detection matches what the parser dispatches on;
@@ -206,8 +207,10 @@ public class ParserBolt extends BaseRichBolt {
                     LOG.warn("Failed to detect MIME type for {}: {}", url, e.getMessage());
                 }
                 if (mimeType != null) {
-                    // write back so downstream code and metadata consumers see
-                    // the same value (avoids a second detection pass)
+                    // write back for the rejected-tuple path only: AutoDetectParser
+                    // re-detects on a successful parse and the copy loop overwrites this;
+                    // the value here is only visible when the tuple is failed, useful for
+                    // debugging why a document was rejected by the whitelist
                     metadata.setValue("parse.Content-Type", mimeType);
                 }
             }

--- a/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
@@ -190,7 +190,7 @@ public class ParserBolt extends BaseRichBolt {
                     // the hint narrows the magic result: when bytes are unrecognised Tika
                     // returns application/octet-stream and the hint specialises it, so the
                     // effective type matches what AutoDetectParser dispatches on
-                    detectionMd.set(org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
+                    detectionMd.set(org.apache.tika.metadata.HttpHeaders.CONTENT_TYPE, httpCTHint);
                 }
                 // pass the filename so detection matches what the parser dispatches on;
                 // without it, an ambiguous byte sequence (e.g. plain text with a .html
@@ -201,8 +201,8 @@ public class ParserBolt extends BaseRichBolt {
                 } catch (MalformedURLException e1) {
                     throw new IllegalStateException("Malformed URL", e1);
                 }
-                try {
-                    mimeType = tika.detect(new ByteArrayInputStream(content), detectionMd);
+                try (TikaInputStream tis = TikaInputStream.get(content)) {
+                    mimeType = tika.detect(tis, detectionMd);
                 } catch (IOException e) {
                     LOG.warn("Failed to detect MIME type for {}: {}", url, e.getMessage());
                 }

--- a/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
+++ b/external/tika/src/main/java/org/apache/stormcrawler/tika/ParserBolt.java
@@ -173,11 +173,34 @@ public class ParserBolt extends BaseRichBolt {
         // check that the mimetype is in the whitelist
         if (!mimeTypeWhiteList.isEmpty()) {
             boolean mt_match = false;
-            // see if a mimetype was guessed in JSOUPBolt
+            // see if a mimetype was detected already (e.g. by JSoupParserBolt)
             String mimeType = metadata.getFirstValue("parse.Content-Type");
-            // otherwise rely on what could have been obtained from HTTP
             if (mimeType == null) {
-                mimeType = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
+                // parse.Content-Type is absent: detect from content bytes so that
+                // the whitelist is evaluated against the same type Tika will use
+                // to select a parser, not the server-declared HTTP header which is
+                // untrusted and may differ from what the bytes actually are.
+                String httpCTHint =
+                        metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
+                org.apache.tika.metadata.Metadata detectionMd =
+                        new org.apache.tika.metadata.Metadata();
+                if (StringUtils.isNotBlank(httpCTHint)) {
+                    // pass the header as a hint only — detect() weighs it but
+                    // content bytes take precedence
+                    detectionMd.set(
+                            org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
+                }
+                try {
+                    mimeType =
+                            tika.detect(new ByteArrayInputStream(content), detectionMd);
+                } catch (IOException e) {
+                    LOG.warn("Failed to detect MIME type for {}: {}", url, e.getMessage());
+                }
+                if (mimeType != null) {
+                    // write back so downstream code and metadata consumers see
+                    // the same value (avoids a second detection pass)
+                    metadata.setValue("parse.Content-Type", mimeType);
+                }
             }
             if (mimeType != null) {
                 for (Pattern mt : mimeTypeWhiteList) {

--- a/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
+++ b/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.tika;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.http.HttpHeaders;
+import org.apache.storm.task.OutputCollector;
+import org.apache.stormcrawler.Constants;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.TestUtil;
+import org.apache.stormcrawler.parse.ParsingTester;
+import org.apache.stormcrawler.persistence.Status;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for: when no parse.Content-Type is present, ParserBolt must evaluate
+ * parser.mimetype.whitelist against the byte-detected MIME type (via tika.detect()), not the
+ * server-declared HTTP Content-Type header. Previously the whitelist checked the header while
+ * Tika's AutoDetectParser dispatched on the bytes, allowing a server to claim a whitelisted type
+ * while serving arbitrary content.
+ */
+class ParserBoltWhitelistDetectionTest extends ParsingTester {
+
+    @BeforeEach
+    void setupParserBolt() {
+        bolt = new ParserBolt();
+        setupParserBolt(bolt);
+    }
+
+    /**
+     * The whitelist allows Word documents (application/.+word.*). The server header claims
+     * Word, but the body bytes are plain HTML. After the fix, detection on bytes yields
+     * text/html which does NOT match the whitelist, so the document must be rejected with ERROR.
+     */
+    @Test
+    void whitelistAppliesToTheDetectedType() throws IOException {
+        Map<String, Object> conf = new HashMap<>();
+        // the whitelist shipped by the archetypes
+        conf.put("parser.mimetype.whitelist", "application/.+word.*");
+        conf.put(ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, "http.");
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        // no parse.Content-Type: no JSoupParserBolt upstream, or detect.mimetype disabled
+        Metadata metadata = new Metadata();
+        metadata.addValue(
+                "http." + HttpHeaders.CONTENT_TYPE,
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        // the body is NOT a word document
+        byte[] content =
+                "<html><body><p>not a word document</p></body></html>"
+                        .getBytes(StandardCharsets.UTF_8);
+        parse("https://example.org/doc.docx", content, metadata);
+
+        System.out.println("detected type: " + metadata.getFirstValue("parse.Content-Type"));
+        System.out.println("emitted documents: " + output.getEmitted().size());
+
+        List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertEquals(
+                1, status.size(), "content not matching the whitelist should be rejected");
+        Assertions.assertEquals(
+                Status.ERROR,
+                status.get(0).get(2),
+                "status should be ERROR for mismatched content type");
+    }
+
+    /**
+     * Sanity check: when parse.Content-Type IS already present (e.g. set by JSoupParserBolt),
+     * the whitelist check must still use it directly and not re-detect.
+     */
+    @Test
+    void whitelistUsesPreexistingParsedContentType() throws IOException {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("parser.mimetype.whitelist", "text/html.*");
+        conf.put(ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, "http.");
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        Metadata metadata = new Metadata();
+        // simulate JSoupParserBolt having detected the type already
+        metadata.addValue("parse.Content-Type", "text/html; charset=UTF-8");
+        metadata.addValue("http." + HttpHeaders.CONTENT_TYPE, "text/html; charset=UTF-8");
+
+        byte[] content =
+                "<html><body><p>hello</p></body></html>".getBytes(StandardCharsets.UTF_8);
+        parse("https://example.org/index.html", content, metadata);
+
+        // document should pass the whitelist and be emitted (no ERROR on status stream)
+        List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
+        boolean hasError =
+                status != null
+                        && status.stream()
+                                .anyMatch(row -> Status.ERROR.equals(row.get(2)));
+        Assertions.assertFalse(hasError, "whitelisted HTML document should not be rejected");
+    }
+}

--- a/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
+++ b/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
@@ -111,4 +111,35 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
                 status != null && status.stream().anyMatch(row -> Status.ERROR.equals(row.get(2)));
         Assertions.assertFalse(hasError, "whitelisted HTML document should not be rejected");
     }
+
+    /**
+     * Plain-text bytes with a .html URL extension. Without the filename hint, Tika resolves the
+     * ambiguous bytes as text/plain; with it, the extension pushes detection to text/html. The
+     * whitelist is set to text/html.*, so the document must be accepted — verifying that the same
+     * RESOURCE_NAME_KEY hint is passed to both the whitelist check and the parser dispatch.
+     */
+    @Test
+    void filenameHintInfluencesDetection() throws IOException {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put("parser.mimetype.whitelist", "text/html.*");
+        conf.put(ProtocolResponse.PROTOCOL_MD_PREFIX_PARAM, "http.");
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), new OutputCollector(output));
+
+        // no parse.Content-Type, no Content-Type header — detection relies on bytes + filename
+        Metadata metadata = new Metadata();
+
+        // plain text bytes: no HTML magic, ambiguous without the filename hint
+        byte[] content = "just some plain text, no html tags".getBytes(StandardCharsets.UTF_8);
+
+        // .html extension should push detection to text/html
+        parse("https://example.org/page.html", content, metadata);
+
+        System.out.println("detected type: " + metadata.getFirstValue("parse.Content-Type"));
+
+        List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
+        boolean hasError =
+                status != null && status.stream().anyMatch(row -> Status.ERROR.equals(row.get(2)));
+        Assertions.assertFalse(
+                hasError, "document with .html URL should be accepted by text/html.* whitelist");
+    }
 }

--- a/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
+++ b/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
@@ -50,9 +50,9 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
     }
 
     /**
-     * The whitelist allows Word documents (application/.+word.*). The server header claims
-     * Word, but the body bytes are plain HTML. After the fix, detection on bytes yields
-     * text/html which does NOT match the whitelist, so the document must be rejected with ERROR.
+     * The whitelist allows Word documents (application/.+word.*). The server header claims Word,
+     * but the body bytes are plain HTML. After the fix, detection on bytes yields text/html which
+     * does NOT match the whitelist, so the document must be rejected with ERROR.
      */
     @Test
     void whitelistAppliesToTheDetectedType() throws IOException {
@@ -87,8 +87,8 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
     }
 
     /**
-     * Sanity check: when parse.Content-Type IS already present (e.g. set by JSoupParserBolt),
-     * the whitelist check must still use it directly and not re-detect.
+     * Sanity check: when parse.Content-Type IS already present (e.g. set by JSoupParserBolt), the
+     * whitelist check must still use it directly and not re-detect.
      */
     @Test
     void whitelistUsesPreexistingParsedContentType() throws IOException {
@@ -102,16 +102,13 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
         metadata.addValue("parse.Content-Type", "text/html; charset=UTF-8");
         metadata.addValue("http." + HttpHeaders.CONTENT_TYPE, "text/html; charset=UTF-8");
 
-        byte[] content =
-                "<html><body><p>hello</p></body></html>".getBytes(StandardCharsets.UTF_8);
+        byte[] content = "<html><body><p>hello</p></body></html>".getBytes(StandardCharsets.UTF_8);
         parse("https://example.org/index.html", content, metadata);
 
         // document should pass the whitelist and be emitted (no ERROR on status stream)
         List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
         boolean hasError =
-                status != null
-                        && status.stream()
-                                .anyMatch(row -> Status.ERROR.equals(row.get(2)));
+                status != null && status.stream().anyMatch(row -> Status.ERROR.equals(row.get(2)));
         Assertions.assertFalse(hasError, "whitelisted HTML document should not be rejected");
     }
 }

--- a/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
+++ b/external/tika/src/test/java/org/apache/stormcrawler/tika/ParserBoltWhitelistDetectionTest.java
@@ -74,8 +74,12 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
                         .getBytes(StandardCharsets.UTF_8);
         parse("https://example.org/doc.docx", content, metadata);
 
-        System.out.println("detected type: " + metadata.getFirstValue("parse.Content-Type"));
-        System.out.println("emitted documents: " + output.getEmitted().size());
+        // detection must have resolved to text/html, not the server-declared Word type
+        String detected = metadata.getFirstValue("parse.Content-Type");
+        Assertions.assertNotNull(detected, "detected MIME type must be written back");
+        Assertions.assertTrue(
+                detected.startsWith("text/html"),
+                "HTML bytes must be detected as text/html, got: " + detected);
 
         List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
         Assertions.assertEquals(
@@ -87,8 +91,9 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
     }
 
     /**
-     * Sanity check: when parse.Content-Type IS already present (e.g. set by JSoupParserBolt), the
-     * whitelist check must still use it directly and not re-detect.
+     * Sanity check: when parse.Content-Type IS already present the whitelist must use it directly
+     * without re-detecting. Uses plain-text bytes at a .txt URL so that any re-detection would
+     * yield text/plain, not text/html — proving the preset value is trusted.
      */
     @Test
     void whitelistUsesPreexistingParsedContentType() throws IOException {
@@ -100,16 +105,22 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
         Metadata metadata = new Metadata();
         // simulate JSoupParserBolt having detected the type already
         metadata.addValue("parse.Content-Type", "text/html; charset=UTF-8");
-        metadata.addValue("http." + HttpHeaders.CONTENT_TYPE, "text/html; charset=UTF-8");
+        // HTTP header also says text/plain to make re-detection diverge if it runs
+        metadata.addValue("http." + HttpHeaders.CONTENT_TYPE, "text/plain");
 
-        byte[] content = "<html><body><p>hello</p></body></html>".getBytes(StandardCharsets.UTF_8);
-        parse("https://example.org/index.html", content, metadata);
+        // plain-text bytes at a .txt URL: re-detection would yield text/plain, not text/html
+        byte[] content = "just some plain text, no html tags".getBytes(StandardCharsets.UTF_8);
+        parse("https://example.org/file.txt", content, metadata);
 
-        // document should pass the whitelist and be emitted (no ERROR on status stream)
+        // proof that the pre-existing parse.Content-Type was trusted: if the whitelist had
+        // re-detected the bytes (yielding text/plain), the text/html.* pattern would not have
+        // matched and the bolt would have emitted ERROR — so no ERROR means the preset was used.
+        // (note: AutoDetectParser overwrites parse.Content-Type on a successful parse, so the
+        // value after parse() reflects parse-time detection, not the whitelist check.)
         List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
         boolean hasError =
                 status != null && status.stream().anyMatch(row -> Status.ERROR.equals(row.get(2)));
-        Assertions.assertFalse(hasError, "whitelisted HTML document should not be rejected");
+        Assertions.assertFalse(hasError, "whitelisted document should not be rejected");
     }
 
     /**
@@ -134,7 +145,12 @@ class ParserBoltWhitelistDetectionTest extends ParsingTester {
         // .html extension should push detection to text/html
         parse("https://example.org/page.html", content, metadata);
 
-        System.out.println("detected type: " + metadata.getFirstValue("parse.Content-Type"));
+        // the filename hint must have steered detection to text/html
+        String detected = metadata.getFirstValue("parse.Content-Type");
+        Assertions.assertNotNull(detected, "detected MIME type must be written back");
+        Assertions.assertTrue(
+                detected.startsWith("text/html"),
+                ".html filename hint must resolve detection to text/html, got: " + detected);
 
         List<List<Object>> status = output.getEmitted(Constants.StatusStreamName);
         boolean hasError =


### PR DESCRIPTION
# Fix `parser.mimetype.whitelist` evaluating against the HTTP response header instead of the detected content type

## The problem

`ParserBolt.execute()` checks `parser.mimetype.whitelist` before parsing. When `parse.Content-Type`
is present in the metadata (written by `JSoupParserBolt` when `detect.mimetype` is true), it is used
for the whitelist check and also drives Tika's `AutoDetectParser` — the two are in agreement.

When `parse.Content-Type` is **absent** — because `detect.mimetype` is false, or because the topology
feeds `ParserBolt` directly without `JSoupParserBolt` upstream — the code fell back to the
`Content-Type` response header supplied by the fetched server:

```java
// otherwise rely on what could have been obtained from HTTP
if (mimeType == null) {
    mimeType = metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
}
```

The whitelist was then evaluated against this server-declared value, while Tika's
`AutoDetectParser` dispatched on the **raw content bytes**. A server can claim any MIME type in its
response header, so the two sources can disagree. In the worst case a server reports a whitelisted
type (e.g. `application/vnd.openxmlformats-officedocument.wordprocessingml.document`) while
serving an entirely different payload (e.g. HTML). The whitelist gate opened, and Tika parsed
whatever the bytes actually were.

The practical impact is limited in the common archetype setup because `JSoupParserBolt` runs ahead
of the Tika bolt with detection enabled, so `parse.Content-Type` is almost always present.
The gap opens in two real scenarios:

- `detect.mimetype: false` in the crawler configuration.
- A custom topology that wires `FetcherBolt` directly to `ParserBolt` without a JSoup stage.

In both cases the whitelist was not doing the job its name and the archetype documentation imply:
controlling **which document types this bolt parses**.

## What this PR changes

### `ParserBolt.execute()` — detect from bytes when `parse.Content-Type` is absent

When the metadata key `parse.Content-Type` is missing, the bolt now calls `tika.detect()` on the
content bytes before evaluating the whitelist, rather than trusting the server header:

```java
if (mimeType == null) {
    String httpCTHint =
            metadata.getFirstValue(HttpHeaders.CONTENT_TYPE, this.protocolMDprefix);
    org.apache.tika.metadata.Metadata detectionMd = new org.apache.tika.metadata.Metadata();
    if (StringUtils.isNotBlank(httpCTHint)) {
        // pass the header as a hint only — detect() weighs it but bytes take precedence
        detectionMd.set(org.apache.tika.metadata.Metadata.CONTENT_TYPE, httpCTHint);
    }
    // pass the filename so detection matches what the parser dispatches on
    URL _url = URLUtil.toURL(url);
    detectionMd.set(TikaCoreProperties.RESOURCE_NAME_KEY, _url.getFile());
    mimeType = tika.detect(new ByteArrayInputStream(content), detectionMd);
    if (mimeType != null) {
        metadata.setValue("parse.Content-Type", mimeType);
    }
}
```

The HTTP response header is still passed to Tika as a **hint**. Content bytes take precedence when
the two disagree. The filename extracted from the URL is also passed as a hint — without it,
ambiguous bytes (e.g. plain text at a `.html` URL) can resolve differently in the whitelist check
vs. at parse dispatch time. The result is written back into `parse.Content-Type` so both the
whitelist gate and Tika's `AutoDetectParser` are bound to the same type.

**Behaviour in the common case is unchanged.** When `parse.Content-Type` is already present (the
normal path with `JSoupParserBolt` upstream), the new block is not entered.

### Behaviour changes worth noting in release notes

**Type mismatch rejection.** Documents whose server-declared `Content-Type` matched the whitelist
but whose bytes are detected as a different type will now be **rejected** where they were
previously parsed. This is the correct outcome — the whitelist was not enforcing what operators
expected — but operators who relied on the previous behaviour should be aware.

**Undetectable content (`application/octet-stream`) rejection.** Previously, truly undetectable
binary content (no magic bytes Tika can match) would pass the whitelist if the server header
claimed a whitelisted type, because the whitelist checked that header. Now the whitelist checks
the byte-detected type, which for undetectable content is `application/octet-stream`. Unless the
whitelist explicitly includes `application/octet-stream`, such documents will be rejected. This is
the stricter and more correct behaviour, but operators should be aware the rejection boundary has
changed.

Restricting the parser set in `tika-config.xml` is a complementary defence in depth: it bounds
which parsers can be selected at all, regardless of what the whitelist or detection step resolves.

## Tests

### `ParserBoltWhitelistDetectionTest` (new, `external/tika`)

**`whitelistAppliesToTheDetectedType`** — reproduces the original bug:

- Whitelist: `application/.+word.*` (the pattern shipped by the archetypes).
- Server `Content-Type` header: `application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
- Body bytes: plain HTML — `<html><body><p>not a word document</p></body></html>`.
- No `parse.Content-Type` in metadata (simulates a topology without JSoupParserBolt upstream).

Before this fix the bolt parsed the HTML and emitted a document. After this fix the bolt detects
`text/html` from the bytes, the whitelist does not match, and the tuple is emitted on the status
stream with `Status.ERROR`.

**`whitelistUsesPreexistingParsedContentType`** — sanity check for the unchanged common path:

- `parse.Content-Type` is set to `text/html; charset=UTF-8` (as JSoupParserBolt would write it).
- Whitelist: `text/html.*`.
- Asserts that the document is accepted and no ERROR status is emitted.

**`filenameHintInfluencesDetection`** — pins the `RESOURCE_NAME_KEY` fix:

- URL: `https://example.org/page.html` (`.html` extension).
- Body: plain-text bytes with no HTML markup — ambiguous without the filename hint.
- No `parse.Content-Type`, no `Content-Type` header.
- Whitelist: `text/html.*`.

Without the filename hint the bytes alone resolve to `text/plain` and the whitelist rejects the
document. With the hint, Tika resolves `text/html`, the whitelist accepts it, and the detection
matches what the parser would dispatch on.

## Verification

```
# install core (editorconfig check is a LF/CRLF issue on Windows; bypass validate phase)
mvn -pl core compiler:compile compiler:testCompile jar:jar install:install -DskipTests

# run the new tests
mvn -pl external/tika test -Dtest=ParserBoltWhitelistDetectionTest
```

```
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

Detected types printed during the test run:

```
detected type: text/html; charset=ISO-8859-1   ← test 1: HTML bytes correctly identified, Word header ignored
detected type: text/html                        ← test 3: plain bytes + .html filename → text/html
emitted documents: 0                            ← test 1: mismatched document rejected
```

The bolt rejects the mismatched document and the filename hint correctly resolves ambiguous content.
