### PR TITLE
URLFilters: treat an exception from a filter as a rejection

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -56,8 +57,18 @@ public class URLFilters extends URLFilter implements JSONResource {
 
     private URLFilter[] filters;
 
+    private final AtomicLong filteredOut = new AtomicLong();
+
     private URLFilters() {
         filters = new URLFilters[0];
+    }
+
+    /**
+     * Number of URLs rejected because a filter in the chain threw an exception. A rejected URL is
+     * the safe verdict: a chain which throws must not widen what the crawl accepts.
+     */
+    public long getExceptionsCount() {
+        return filteredOut.get();
     }
 
     /**
@@ -113,18 +124,23 @@ public class URLFilters extends URLFilter implements JSONResource {
             @Nullable Metadata sourceMetadata,
             @NotNull String urlToFilter) {
         String normalizedUrl = urlToFilter;
-        try {
-            for (URLFilter filter : filters) {
-                long start = System.currentTimeMillis();
+        for (URLFilter filter : filters) {
+            long start = System.currentTimeMillis();
+            try {
                 normalizedUrl = filter.filter(sourceUrl, sourceMetadata, normalizedUrl);
-                long end = System.currentTimeMillis();
-                LOG.debug("URLFilter {} took {} msec", filter.getClass().getName(), end - start);
-                if (normalizedUrl == null) {
-                    break;
-                }
+            } catch (Exception e) {
+                // a filter which throws must not disable the filters after it:
+                // treat the URL as rejected, the same verdict a broken chain
+                // must not be allowed to widen
+                LOG.error("URL filter {} threw exception", filter.getClass().getName(), e);
+                filteredOut.incrementAndGet();
+                return null;
             }
-        } catch (Exception e) {
-            LOG.error("URL filtering threw exception", e);
+            long end = System.currentTimeMillis();
+            LOG.debug("URLFilter {} took {} msec", filter.getClass().getName(), end - start);
+            if (normalizedUrl == null) {
+                break;
+            }
         }
         return normalizedUrl;
     }
@@ -189,25 +205,28 @@ public class URLFilters extends URLFilter implements JSONResource {
         try {
             URLFilters filters = new URLFilters(conf, configFile);
             String normalizedUrl = inputUrl;
-            try {
-                for (URLFilter filter : filters.filters) {
-                    long start = System.currentTimeMillis();
+            for (URLFilter filter : filters.filters) {
+                long start = System.currentTimeMillis();
+                try {
                     normalizedUrl =
                             filter.filter(URLUtil.toURL(sourceUrl), new Metadata(), normalizedUrl);
-                    long end = System.currentTimeMillis();
-                    System.out.println(
-                            "\t["
-                                    + filter.getClass().getName()
-                                    + "] "
-                                    + (end - start)
-                                    + "msec => "
-                                    + normalizedUrl);
-                    if (normalizedUrl == null) {
-                        break;
-                    }
+                } catch (Exception e) {
+                    LOG.error("URL filter {} threw exception", filter.getClass().getName(), e);
+                    System.err.println(
+                            "\t[" + filter.getClass().getName() + "] threw " + e + " => rejected");
+                    normalizedUrl = null;
                 }
-            } catch (Exception e) {
-                LOG.error("URL filtering threw exception", e);
+                long end = System.currentTimeMillis();
+                System.out.println(
+                        "\t["
+                                + filter.getClass().getName()
+                                + "] "
+                                + (end - start)
+                                + "msec => "
+                                + normalizedUrl);
+                if (normalizedUrl == null) {
+                    break;
+                }
             }
         } catch (IOException e) {
             LOG.error("Failed to initialize URLFilters", e);

--- a/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
@@ -21,7 +21,12 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -38,13 +43,6 @@ import org.apache.stormcrawler.util.URLUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Wrapper for the URLFilters defined in a JSON configuration.
@@ -66,14 +64,6 @@ public class URLFilters extends URLFilter implements JSONResource {
     }
 
     /**
-     * Number of URLs rejected because a filter in the chain threw an exception. A rejected URL is
-     * the safe verdict: a chain which throws must not widen what the crawl accepts.
-     */
-    public long getExceptionsCount() {
-        return exceptionsCount.get();
-    }
-
-    /**
      * Loads the filters from a JSON configuration file.
      *
      * @throws IOException
@@ -86,6 +76,14 @@ public class URLFilters extends URLFilter implements JSONResource {
         } catch (Exception e) {
             throw new IOException("Unable to build JSON object from file", e);
         }
+    }
+
+    /**
+     * Number of URLs rejected because a filter in the chain threw an exception. A rejected URL is
+     * the safe verdict: a chain which throws must not widen what the crawl accepts.
+     */
+    public long getExceptionsCount() {
+        return exceptionsCount.get();
     }
 
     private String configFile = "urlfilters.json";

--- a/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
@@ -21,12 +21,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -44,6 +39,13 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
  * Wrapper for the URLFilters defined in a JSON configuration.
  *
@@ -57,7 +59,7 @@ public class URLFilters extends URLFilter implements JSONResource {
 
     private URLFilter[] filters;
 
-    private final AtomicLong filteredOut = new AtomicLong();
+    private final AtomicLong exceptionsCount = new AtomicLong();
 
     private URLFilters() {
         filters = new URLFilters[0];
@@ -68,7 +70,7 @@ public class URLFilters extends URLFilter implements JSONResource {
      * the safe verdict: a chain which throws must not widen what the crawl accepts.
      */
     public long getExceptionsCount() {
-        return filteredOut.get();
+        return exceptionsCount.get();
     }
 
     /**
@@ -133,7 +135,7 @@ public class URLFilters extends URLFilter implements JSONResource {
                 // treat the URL as rejected, the same verdict a broken chain
                 // must not be allowed to widen
                 LOG.error("URL filter {} threw exception", filter.getClass().getName(), e);
-                filteredOut.incrementAndGet();
+                exceptionsCount.incrementAndGet();
                 return null;
             }
             long end = System.currentTimeMillis();
@@ -212,8 +214,6 @@ public class URLFilters extends URLFilter implements JSONResource {
                             filter.filter(URLUtil.toURL(sourceUrl), new Metadata(), normalizedUrl);
                 } catch (Exception e) {
                     LOG.error("URL filter {} threw exception", filter.getClass().getName(), e);
-                    System.err.println(
-                            "\t[" + filter.getClass().getName() + "] threw " + e + " => rejected");
                     normalizedUrl = null;
                 }
                 long end = System.currentTimeMillis();

--- a/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/URLFilters.java
@@ -78,10 +78,7 @@ public class URLFilters extends URLFilter implements JSONResource {
         }
     }
 
-    /**
-     * Number of URLs rejected because a filter in the chain threw an exception. A rejected URL is
-     * the safe verdict: a chain which throws must not widen what the crawl accepts.
-     */
+    /** Number of URLs rejected because a filter in the chain threw an exception. */
     public long getExceptionsCount() {
         return exceptionsCount.get();
     }
@@ -129,9 +126,6 @@ public class URLFilters extends URLFilter implements JSONResource {
             try {
                 normalizedUrl = filter.filter(sourceUrl, sourceMetadata, normalizedUrl);
             } catch (Exception e) {
-                // a filter which throws must not disable the filters after it:
-                // treat the URL as rejected, the same verdict a broken chain
-                // must not be allowed to widen
                 LOG.error("URL filter {} threw exception", filter.getClass().getName(), e);
                 exceptionsCount.incrementAndGet();
                 return null;

--- a/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
@@ -348,7 +348,10 @@ public class FastURLFilter extends URLFilter implements JSONResource {
             }
             // no match?
             if (type == null) {
-                return;
+                // a rule without a type would throw when evaluated; fail at
+                // load time instead, where the misconfiguration belongs
+                throw new IllegalArgumentException(
+                        "FastURLFilter rule does not start with a known type: " + line);
             }
 
             String patternString = line.substring(offset).trim();

--- a/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
+++ b/core/src/main/java/org/apache/stormcrawler/filtering/regex/FastURLFilter.java
@@ -348,8 +348,6 @@ public class FastURLFilter extends URLFilter implements JSONResource {
             }
             // no match?
             if (type == null) {
-                // a rule without a type would throw when evaluated; fail at
-                // load time instead, where the misconfiguration belongs
                 throw new IllegalArgumentException(
                         "FastURLFilter rule does not start with a known type: " + line);
             }

--- a/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.filtering;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.util.URLUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Behaviour of the filter chain when one of its filters throws. */
+class URLFiltersExceptionTest {
+
+    /** Stands in for any filter that throws at evaluation time. */
+    public static class ThrowingURLFilter extends URLFilter {
+        @Override
+        public @Nullable String filter(
+                @Nullable URL sourceUrl,
+                @Nullable Metadata sourceMetadata,
+                @NotNull String urlToFilter) {
+            throw new NullPointerException("filter blew up");
+        }
+    }
+
+    /** Stands in for an exclusion rule placed after it, such as the private-range regexes. */
+    public static class RejectEverythingURLFilter extends URLFilter {
+        @Override
+        public @Nullable String filter(
+                @Nullable URL sourceUrl,
+                @Nullable Metadata sourceMetadata,
+                @NotNull String urlToFilter) {
+            return null;
+        }
+    }
+
+    @Test
+    void urlIsRejectedWhenAnEarlierFilterThrows() throws IOException, MalformedURLException {
+        Map<String, Object> conf = new HashMap<>();
+        URLFilters filters = new URLFilters(conf, "urlfilters-throwing.json");
+        URL source = URLUtil.toURL("http://www.example.com/index.html");
+        Assertions.assertNull(
+                filters.filter(source, new Metadata(), "http://www.example.com/outlink.html"),
+                "a filter that throws must reject the URL, not let it through");
+        Assertions.assertEquals(1, filters.getExceptionsCount());
+    }
+
+    @Test
+    void rejectionShortensTheChain() throws IOException, MalformedURLException {
+        Map<String, Object> conf = new HashMap<>();
+        URLFilters filters = new URLFilters(conf, "urlfilters-throwing.json");
+        URL source = URLUtil.toURL("http://www.example.com/index.html");
+        Assertions.assertNull(filters.filter(source, new Metadata(), "http://www.example.com/"));
+        Assertions.assertEquals(1, filters.getExceptionsCount());
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
@@ -17,19 +17,18 @@
 
 package org.apache.stormcrawler.filtering;
 
-import org.apache.stormcrawler.Metadata;
-import org.apache.stormcrawler.util.URLUtil;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.util.URLUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Behaviour of the filter chain when one of its filters throws. */
 class URLFiltersExceptionTest {

--- a/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 /** Behaviour of the filter chain when one of its filters throws. */
 class URLFiltersExceptionTest {
 
-    /** Stands in for any filter that throws at evaluation time. */
     public static class ThrowingURLFilter extends URLFilter {
         @Override
         public @Nullable String filter(
@@ -44,7 +43,6 @@ class URLFiltersExceptionTest {
         }
     }
 
-    /** Stands in for an exclusion rule placed after it, such as the private-range regexes. */
     public static class RejectEverythingURLFilter extends URLFilter {
         @Override
         public @Nullable String filter(
@@ -55,7 +53,6 @@ class URLFiltersExceptionTest {
         }
     }
 
-    /** Counts how often it ran; placed after the thrower to prove the chain stops. */
     public static class CountingURLFilter extends URLFilter {
         public static final AtomicInteger EVALUATIONS = new AtomicInteger();
 
@@ -80,7 +77,6 @@ class URLFiltersExceptionTest {
         Assertions.assertEquals(1, filters.getExceptionsCount());
     }
 
-    /** The chain stops at the throwing filter: the filters after it never run. */
     @Test
     void rejectionShortensTheChain() throws IOException, MalformedURLException {
         Map<String, Object> conf = new HashMap<>();

--- a/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/filtering/URLFiltersExceptionTest.java
@@ -17,17 +17,19 @@
 
 package org.apache.stormcrawler.filtering;
 
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.util.URLUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Behaviour of the filter chain when one of its filters throws. */
 class URLFiltersExceptionTest {
@@ -54,6 +56,20 @@ class URLFiltersExceptionTest {
         }
     }
 
+    /** Counts how often it ran; placed after the thrower to prove the chain stops. */
+    public static class CountingURLFilter extends URLFilter {
+        public static final AtomicInteger EVALUATIONS = new AtomicInteger();
+
+        @Override
+        public @Nullable String filter(
+                @Nullable URL sourceUrl,
+                @Nullable Metadata sourceMetadata,
+                @NotNull String urlToFilter) {
+            EVALUATIONS.incrementAndGet();
+            return urlToFilter;
+        }
+    }
+
     @Test
     void urlIsRejectedWhenAnEarlierFilterThrows() throws IOException, MalformedURLException {
         Map<String, Object> conf = new HashMap<>();
@@ -65,12 +81,18 @@ class URLFiltersExceptionTest {
         Assertions.assertEquals(1, filters.getExceptionsCount());
     }
 
+    /** The chain stops at the throwing filter: the filters after it never run. */
     @Test
     void rejectionShortensTheChain() throws IOException, MalformedURLException {
         Map<String, Object> conf = new HashMap<>();
-        URLFilters filters = new URLFilters(conf, "urlfilters-throwing.json");
+        URLFilters filters = new URLFilters(conf, "urlfilters-throwing-counting.json");
+        CountingURLFilter.EVALUATIONS.set(0);
         URL source = URLUtil.toURL("http://www.example.com/index.html");
         Assertions.assertNull(filters.filter(source, new Metadata(), "http://www.example.com/"));
+        Assertions.assertEquals(
+                0,
+                CountingURLFilter.EVALUATIONS.get(),
+                "a filter placed after the one that threw must not be evaluated");
         Assertions.assertEquals(1, filters.getExceptionsCount());
     }
 }

--- a/core/src/test/resources/urlfilters-throwing-counting.json
+++ b/core/src/test/resources/urlfilters-throwing-counting.json
@@ -1,0 +1,12 @@
+{
+	"org.apache.stormcrawler.filtering.URLFilters": [
+		{
+			"class": "org.apache.stormcrawler.filtering.URLFiltersExceptionTest$ThrowingURLFilter",
+			"name": "ThrowingURLFilter"
+		},
+		{
+			"class": "org.apache.stormcrawler.filtering.URLFiltersExceptionTest$CountingURLFilter",
+			"name": "CountingURLFilter"
+		}
+	]
+}

--- a/core/src/test/resources/urlfilters-throwing.json
+++ b/core/src/test/resources/urlfilters-throwing.json
@@ -1,0 +1,12 @@
+{
+	"org.apache.stormcrawler.filtering.URLFilters": [
+		{
+			"class": "org.apache.stormcrawler.filtering.URLFiltersExceptionTest$ThrowingURLFilter",
+			"name": "ThrowingURLFilter"
+		},
+		{
+			"class": "org.apache.stormcrawler.filtering.URLFiltersExceptionTest$RejectEverythingURLFilter",
+			"name": "RejectEverythingURLFilter"
+		}
+	]
+}


### PR DESCRIPTION
Fixes #2084.

The try/catch wrapped the whole chain: when a filter threw, the catch logged the exception and fell through to the value the last successful filter had produced, so callers such as `StatusEmitterBolt.filterOutlink` treated the URL as accepted and every filter after the one that threw was skipped — including the regex exclusions the archetype places last.

- the try/catch now sits inside the loop: it logs which filter threw and returns null, so a broken chain cannot widen what the crawl accepts
- `main()` applies the same verdict so the command line tool agrees with the topology
- a counter (`getExceptionsCount()`) records how often it happens
- `FastURLFilter.Rule` rejects a rule line without a recognised type at load time instead of building a rule with a null type that throws when evaluated

This changes behaviour for topologies that currently have a throwing filter and did not notice: those URLs start being dropped instead of emitted.