### PR TITLE
Robots.txt fetch no longer replaces the configured content limit

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -64,9 +64,16 @@ public class HttpRobotRulesParser extends RobotRulesParser {
         super.setConf(conf);
         allowForbidden = ConfUtils.getBoolean(conf, "http.robots.403.allow", true);
         fetchRobotsMd = new Metadata();
-        /* http.content.limit for fetching the robots.txt */
+        /*
+         * http.content.limit for fetching the robots.txt. The default of -1
+         * means "same as http.content.limit": writing the key into the fetch
+         * metadata would override the global limit of the protocol with "no
+         * limit", so it is only set when a robots specific limit is configured.
+         */
         int robotsTxtContentLimit = ConfUtils.getInt(conf, "http.robots.content.limit", -1);
-        fetchRobotsMd.addValue("http.content.limit", Integer.toString(robotsTxtContentLimit));
+        if (robotsTxtContentLimit != -1) {
+            fetchRobotsMd.addValue("http.content.limit", Integer.toString(robotsTxtContentLimit));
+        }
         allow5xx = ConfUtils.getBoolean(conf, "http.robots.5xx.allow", false);
         allowCrossOriginRedirects =
                 ConfUtils.getBoolean(conf, "http.robots.redirect.crossorigin.allow", false);

--- a/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -64,12 +64,7 @@ public class HttpRobotRulesParser extends RobotRulesParser {
         super.setConf(conf);
         allowForbidden = ConfUtils.getBoolean(conf, "http.robots.403.allow", true);
         fetchRobotsMd = new Metadata();
-        /*
-         * http.content.limit for fetching the robots.txt. The default of -1
-         * means "same as http.content.limit": writing the key into the fetch
-         * metadata would override the global limit of the protocol with "no
-         * limit", so it is only set when a robots specific limit is configured.
-         */
+        // http.content.limit for fetching the robots.txt, only set when configured
         int robotsTxtContentLimit = ConfUtils.getInt(conf, "http.robots.content.limit", -1);
         if (robotsTxtContentLimit != -1) {
             fetchRobotsMd.addValue("http.content.limit", Integer.toString(robotsTxtContentLimit));

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -442,7 +442,15 @@ public class HttpProtocol extends AbstractHttpProtocol {
             final String pageMaxContentStr = metadata.getFirstValue("http.content.limit");
             if (StringUtils.isNotBlank(pageMaxContentStr)) {
                 try {
-                    pageMaxContent = Integer.parseInt(pageMaxContentStr);
+                    int metadataLimit = Integer.parseInt(pageMaxContentStr);
+                    /*
+                     * per-URL metadata can tighten the limit but not remove it:
+                     * a value of -1 means "no limit" and would turn the finite
+                     * global limit of the operator into an unbounded read
+                     */
+                    if (metadataLimit != -1 || globalMaxContent == -1) {
+                        pageMaxContent = metadataLimit;
+                    }
                 } catch (NumberFormatException e) {
                     LOG.warn("Invalid http.content.limit in metadata: {}", pageMaxContentStr);
                 }

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -443,15 +443,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
             if (StringUtils.isNotBlank(pageMaxContentStr)) {
                 try {
                     int metadataLimit = Integer.parseInt(pageMaxContentStr);
-                    /*
-                     * only -1 means "no limit" here, anything below is a
-                     * configuration error and is ignored. A robots specific
-                     * limit (http.robots.content.limit) may deliberately raise
-                     * the limit above the global one: the robots.txt RFC floor
-                     * is the reason that key exists, so the fetch of the
-                     * robots.txt is allowed a larger read than pages even when
-                     * http.content.limit is smaller.
-                     */
+                    // -1 means no limit, anything below is invalid and ignored
                     if (metadataLimit >= -1 && (metadataLimit != -1 || globalMaxContent == -1)) {
                         pageMaxContent = metadataLimit;
                     }

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -17,33 +17,8 @@
 
 package org.apache.stormcrawler.protocol.okhttp;
 
-import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.security.cert.CertificateException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 import kotlin.Pair;
+
 import okhttp3.Call;
 import okhttp3.CompressionInterceptor;
 import okhttp3.Connection;
@@ -66,7 +41,9 @@ import okhttp3.ResponseBody;
 import okhttp3.Route;
 import okhttp3.brotli.Brotli;
 import okhttp3.zstd.Zstd;
+
 import okio.BufferedSource;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.http.HttpHeaders;
@@ -84,6 +61,34 @@ import org.apache.stormcrawler.util.CookieConverter;
 import org.apache.stormcrawler.util.URLUtil;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 public class HttpProtocol extends AbstractHttpProtocol {
 
@@ -444,11 +449,15 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 try {
                     int metadataLimit = Integer.parseInt(pageMaxContentStr);
                     /*
-                     * per-URL metadata can tighten the limit but not remove it:
-                     * a value of -1 means "no limit" and would turn the finite
-                     * global limit of the operator into an unbounded read
+                     * only -1 means "no limit" here, anything below is a
+                     * configuration error and is ignored. A robots specific
+                     * limit (http.robots.content.limit) may deliberately raise
+                     * the limit above the global one: the robots.txt RFC floor
+                     * is the reason that key exists, so the fetch of the
+                     * robots.txt is allowed a larger read than pages even when
+                     * http.content.limit is smaller.
                      */
-                    if (metadataLimit != -1 || globalMaxContent == -1) {
+                    if (metadataLimit >= -1 && (metadataLimit != -1 || globalMaxContent == -1)) {
                         pageMaxContent = metadataLimit;
                     }
                 } catch (NumberFormatException e) {

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -17,8 +17,33 @@
 
 package org.apache.stormcrawler.protocol.okhttp;
 
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import kotlin.Pair;
-
 import okhttp3.Call;
 import okhttp3.CompressionInterceptor;
 import okhttp3.Connection;
@@ -41,9 +66,7 @@ import okhttp3.ResponseBody;
 import okhttp3.Route;
 import okhttp3.brotli.Brotli;
 import okhttp3.zstd.Zstd;
-
 import okio.BufferedSource;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.apache.http.HttpHeaders;
@@ -61,34 +84,6 @@ import org.apache.stormcrawler.util.CookieConverter;
 import org.apache.stormcrawler.util.URLUtil;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.security.cert.CertificateException;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 public class HttpProtocol extends AbstractHttpProtocol {
 

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -201,8 +201,11 @@ config:
   # http.content.limit when fetching the robots.txt
   # (the robots.txt RFC draft requires to fetch and parse at least 500 kiB,
   #  see https://datatracker.ietf.org/doc/html/draft-rep-wg-topic-00#section-2.5)
+  # A value of -1 means "same as http.content.limit": the robots.txt fetch
+  # then uses whatever limit is configured for pages, including "no limit"
+  # when http.content.limit is -1 too.
   # http.robots.content.limit: 524288  # 512 kiB
-  http.robots.content.limit: -1  # default same as http.content.limit
+  http.robots.content.limit: 524288
 
   # Implementation of RobotRulesParser used by the HTTP protocol implementations
   # to fetch and parse robots.txt. Override to plug in custom robots.txt

--- a/core/src/test/java/org/apache/stormcrawler/protocol/RobotsContentLimitTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/RobotsContentLimitTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.protocol;
+
+import org.apache.storm.Config;
+import org.apache.stormcrawler.Metadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Checks the content limit used for the robots.txt fetch. */
+class RobotsContentLimitTest {
+
+    /** Protocol stub recording the metadata it is called with. */
+    private static class RecordingProtocol implements Protocol {
+
+        Metadata seen;
+
+        @Override
+        public void configure(Config conf) {}
+
+        @Override
+        public ProtocolResponse getProtocolOutput(String url, Metadata metadata) {
+            seen = metadata;
+            return new ProtocolResponse(new byte[0], 200, new Metadata());
+        }
+
+        @Override
+        public crawlercommons.robots.BaseRobotRules getRobotRules(String url) {
+            return null;
+        }
+
+        @Override
+        public void cleanup() {}
+    }
+
+    @Test
+    void robotsFetchKeepsTheGlobalContentLimit() {
+        Config conf = new Config();
+        conf.put("http.agent.name", "this_is_only_a_test");
+        // operator sets a finite limit and does not touch http.robots.content.limit
+        conf.put("http.content.limit", 65536);
+
+        RecordingProtocol protocol = new RecordingProtocol();
+        HttpRobotRulesParser parser = new HttpRobotRulesParser();
+        parser.setConf(conf);
+        parser.getRobotRulesSet(protocol, "http://limit.example.org/");
+
+        String limit = protocol.seen.getFirstValue("http.content.limit");
+        Assertions.assertNull(
+                limit,
+                "the robots.txt fetch should not override the global content limit, but saw: "
+                        + limit);
+    }
+
+    @Test
+    void robotsSpecificLimitIsApplied() {
+        Config conf = new Config();
+        conf.put("http.agent.name", "this_is_only_a_test");
+        conf.put("http.content.limit", 65536);
+        conf.put("http.robots.content.limit", 524288);
+
+        RecordingProtocol protocol = new RecordingProtocol();
+        HttpRobotRulesParser parser = new HttpRobotRulesParser();
+        parser.setConf(conf);
+        parser.getRobotRulesSet(protocol, "http://limit.example.org/");
+
+        Assertions.assertEquals("524288", protocol.seen.getFirstValue("http.content.limit"));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/protocol/RobotsContentLimitTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/RobotsContentLimitTest.java
@@ -17,10 +17,14 @@
 
 package org.apache.stormcrawler.protocol;
 
+import java.io.InputStream;
+import java.util.Map;
 import org.apache.storm.Config;
 import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.util.ConfUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
 /** Checks the content limit used for the robots.txt fetch. */
 class RobotsContentLimitTest {
@@ -80,5 +84,44 @@ class RobotsContentLimitTest {
         parser.getRobotRulesSet(protocol, "http://limit.example.org/");
 
         Assertions.assertEquals("524288", protocol.seen.getFirstValue("http.content.limit"));
+    }
+
+    @Test
+    void anExplicitMinusOneInheritsThePageLimit() {
+        Config conf = new Config();
+        conf.put("http.agent.name", "this_is_only_a_test");
+        conf.put("http.content.limit", 65536);
+        conf.put("http.robots.content.limit", -1);
+
+        RecordingProtocol protocol = new RecordingProtocol();
+        HttpRobotRulesParser parser = new HttpRobotRulesParser();
+        parser.setConf(conf);
+        parser.getRobotRulesSet(protocol, "http://limit.example.org/");
+
+        Assertions.assertNull(protocol.seen.getFirstValue("http.content.limit"));
+    }
+
+    @Test
+    void theShippedDefaultIsHalfAMebibyte() throws Exception {
+        Config conf = new Config();
+        conf.put("http.agent.name", "this_is_only_a_test");
+        conf.putAll(shippedDefaults());
+        Assertions.assertEquals(524288, conf.get("http.robots.content.limit"));
+
+        RecordingProtocol protocol = new RecordingProtocol();
+        HttpRobotRulesParser parser = new HttpRobotRulesParser();
+        parser.setConf(conf);
+        parser.getRobotRulesSet(protocol, "http://limit.example.org/");
+
+        Assertions.assertEquals("524288", protocol.seen.getFirstValue("http.content.limit"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> shippedDefaults() throws Exception {
+        try (InputStream in =
+                RobotsContentLimitTest.class.getResourceAsStream("/crawler-default.yaml")) {
+            Assertions.assertNotNull(in, "crawler-default.yaml is not on the classpath");
+            return ConfUtils.extractConfigElement((Map<String, Object>) new Yaml().load(in));
+        }
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocolContentLimitTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocolContentLimitTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.protocol.okhttp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.zip.GZIPOutputStream;
+import org.apache.storm.Config;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.protocol.AbstractProtocolTest;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Content limit applied by the OkHttp protocol, including the limit passed through the metadata by
+ * the robots.txt fetch.
+ */
+class HttpProtocolContentLimitTest extends AbstractProtocolTest {
+
+    @Override
+    protected Handler[] getHandlers() {
+        return new Handler[] {new SizedContentHandler()};
+    }
+
+    @Test
+    void metadataLimitOfMinusOneDoesNotRemoveTheGlobalLimit() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/plain/4096", "-1");
+        assertEquals(1024, response.getContent().length);
+        assertTrimmedForLength(response);
+    }
+
+    @Test
+    void metadataLimitBelowMinusOneIsIgnored() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/plain/4096", "-2");
+        assertEquals(1024, response.getContent().length);
+        assertTrimmedForLength(response);
+    }
+
+    @Test
+    void nonNumericMetadataLimitIsIgnored() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/plain/4096", "not a number");
+        assertEquals(1024, response.getContent().length);
+        assertTrimmedForLength(response);
+    }
+
+    @Test
+    void metadataLimitMayExceedTheGlobalLimit() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/plain/2048", "4096");
+        assertEquals(2048, response.getContent().length);
+        assertNull(response.getMetadata().getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_KEY));
+    }
+
+    @Test
+    void metadataLimitMayTightenTheGlobalLimit() throws Exception {
+        final ProtocolResponse response = fetch(protocol(4096), "/plain/2048", "512");
+        assertEquals(512, response.getContent().length);
+        assertTrimmedForLength(response);
+    }
+
+    @Test
+    void metadataLimitOfMinusOneAppliesWhenTheGlobalLimitIsUnlimited() throws Exception {
+        final ProtocolResponse response = fetch(protocol(-1), "/plain/2048", "-1");
+        assertEquals(2048, response.getContent().length);
+        assertNull(response.getMetadata().getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_KEY));
+    }
+
+    @Test
+    void noMetadataLimitLeavesTheGlobalLimitInPlace() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/plain/4096", null);
+        assertEquals(1024, response.getContent().length);
+        assertTrimmedForLength(response);
+    }
+
+    @Test
+    void gzippedResponseIsTrimmedOnItsDecompressedLength() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/gzip/4096", "-1");
+        assertEquals(1024, response.getContent().length);
+        assertTrimmedForLength(response);
+    }
+
+    @Test
+    void gzippedResponseIsReadInFullUpToAWidenedLimit() throws Exception {
+        final ProtocolResponse response = fetch(protocol(1024), "/gzip/4096", "8192");
+        assertEquals(4096, response.getContent().length);
+        assertNull(response.getMetadata().getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_KEY));
+    }
+
+    private void assertTrimmedForLength(ProtocolResponse response) {
+        final Metadata md = response.getMetadata();
+        assertEquals("true", md.getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_KEY));
+        assertEquals("length", md.getFirstValue(ProtocolResponse.TRIMMED_RESPONSE_REASON_KEY));
+    }
+
+    /** Fetches a path, optionally passing http.content.limit through the metadata. */
+    private ProtocolResponse fetch(HttpProtocol protocol, String path, String metadataLimit)
+            throws Exception {
+        final Metadata md = new Metadata();
+        if (metadataLimit != null) {
+            md.setValue("http.content.limit", metadataLimit);
+        }
+        return protocol.getProtocolOutput("http://localhost:" + HTTP_PORT + path, md);
+    }
+
+    private HttpProtocol protocol(int globalContentLimit) {
+        final Config conf = new Config();
+        conf.put("http.agent.name", "test");
+        conf.put("http.content.limit", globalContentLimit);
+        final HttpProtocol protocol = new HttpProtocol();
+        protocol.configure(conf);
+        return protocol;
+    }
+
+    /** Serves /plain/&lt;n&gt; and /gzip/&lt;n&gt; as n bytes of uncompressed content. */
+    static class SizedContentHandler extends AbstractHandler {
+
+        @Override
+        public void handle(
+                String target,
+                Request baseRequest,
+                HttpServletRequest request,
+                HttpServletResponse response)
+                throws IOException {
+            baseRequest.setHandled(true);
+            final String[] segments = target.split("/");
+            final int size = Integer.parseInt(segments[2]);
+            final byte[] content = new byte[size];
+            Arrays.fill(content, (byte) 'a');
+            response.setStatus(HttpServletResponse.SC_OK);
+            response.setContentType("text/plain; charset=UTF-8");
+            final byte[] body;
+            if (segments[1].equals("gzip")) {
+                final ByteArrayOutputStream compressed = new ByteArrayOutputStream();
+                try (GZIPOutputStream gzip = new GZIPOutputStream(compressed)) {
+                    gzip.write(content);
+                }
+                body = compressed.toByteArray();
+                response.setHeader("Content-Encoding", "gzip");
+            } else {
+                body = content;
+            }
+            response.setContentLength(body.length);
+            try (OutputStream out = response.getOutputStream()) {
+                out.write(body);
+            }
+        }
+    }
+}

--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -216,7 +216,7 @@ implementation.
 | http.robots.403.allow | true | Allow crawling when robots.txt returns HTTP 403.
 | http.robots.5xx.allow | false | Allow crawling when robots.txt returns a server error (5xx).
 | http.robots.agents | '' | Additional user-agent strings for interpreting robots.txt.
-| http.robots.content.limit | -1 | Maximum bytes to fetch for robots.txt. -1 uses http.content.limit.
+| http.robots.content.limit | 524288 | Maximum bytes to fetch for robots.txt. May be larger than `http.content.limit`, so that a robots.txt is read in full even where pages are truncated. Set to -1 to use `http.content.limit` instead.
 | http.robots.file.skip | false | Ignore robots.txt rules entirely.
 | http.robots.headers.skip | false | Ignore robots directives from HTTP headers.
 | http.robots.meta.skip | false | Ignore robots directives from HTML meta tags.


### PR DESCRIPTION
Fixes #2087.

`HttpRobotRulesParser.setConf` put `http.robots.content.limit` (-1 by default) into the fetch metadata as `http.content.limit`, and `HttpProtocol.getProtocolOutput` applies that value unconditionally — so every robots.txt fetch ran with no limit at all, even when the operator configured a finite `http.content.limit`, although the shipped comment said the default was 'same as http.content.limit'. With no limit, the decompressed body is buffered until `Constants.MAX_ARRAY_SIZE`, just under 2 GB.

- `http.robots.content.limit: -1` now means 'inherit the global limit'; the key is only written into the fetch metadata when a robots-specific limit is configured
- the shipped default of `http.robots.content.limit` is 524288 (512 kiB), the minimum the robots.txt RFC draft asks crawlers to fetch and parse
- `HttpProtocol` ignores a metadata `http.content.limit` of -1 when the global limit is finite, so per-URL metadata can tighten the limit but not remove it