### PR TITLE
Canonicalise hosts for politeness queues and the robots.txt cache

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -187,7 +187,7 @@ public class FetcherBolt extends StatusEmitterBolt {
                     key = u.getHost();
                 }
             } else {
-                key = u.getHost();
+                key = URLUtil.getCanonicalHost(u);
             }
 
             if (key == null) {

--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -19,32 +19,6 @@ package org.apache.stormcrawler.bolt;
 
 import crawlercommons.domains.PaidLevelDomain;
 import crawlercommons.robots.BaseRobotRules;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
-import org.apache.storm.Config;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.utils.TupleUtils;
-import org.apache.storm.utils.Utils;
-import org.apache.stormcrawler.Constants;
-import org.apache.stormcrawler.Metadata;
-import org.apache.stormcrawler.metrics.CrawlerMetrics;
-import org.apache.stormcrawler.metrics.ScopedCounter;
-import org.apache.stormcrawler.metrics.ScopedReducedMetric;
-import org.apache.stormcrawler.persistence.Status;
-import org.apache.stormcrawler.protocol.Protocol;
-import org.apache.stormcrawler.protocol.ProtocolFactory;
-import org.apache.stormcrawler.protocol.ProtocolResponse;
-import org.apache.stormcrawler.protocol.RobotRules;
-import org.apache.stormcrawler.util.ConfUtils;
-import org.apache.stormcrawler.util.URLUtil;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -72,6 +46,30 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.storm.Config;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.TupleUtils;
+import org.apache.storm.utils.Utils;
+import org.apache.stormcrawler.Constants;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.metrics.CrawlerMetrics;
+import org.apache.stormcrawler.metrics.ScopedCounter;
+import org.apache.stormcrawler.metrics.ScopedReducedMetric;
+import org.apache.stormcrawler.persistence.Status;
+import org.apache.stormcrawler.protocol.Protocol;
+import org.apache.stormcrawler.protocol.ProtocolFactory;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.apache.stormcrawler.protocol.RobotRules;
+import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.URLUtil;
+import org.slf4j.LoggerFactory;
 
 /**
  * A multithreaded, queue-based fetcher adapted from Apache Nutch. Enforces the politeness and

--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -19,6 +19,32 @@ package org.apache.stormcrawler.bolt;
 
 import crawlercommons.domains.PaidLevelDomain;
 import crawlercommons.robots.BaseRobotRules;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.storm.Config;
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.apache.storm.utils.TupleUtils;
+import org.apache.storm.utils.Utils;
+import org.apache.stormcrawler.Constants;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.metrics.CrawlerMetrics;
+import org.apache.stormcrawler.metrics.ScopedCounter;
+import org.apache.stormcrawler.metrics.ScopedReducedMetric;
+import org.apache.stormcrawler.persistence.Status;
+import org.apache.stormcrawler.protocol.Protocol;
+import org.apache.stormcrawler.protocol.ProtocolFactory;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.apache.stormcrawler.protocol.RobotRules;
+import org.apache.stormcrawler.util.ConfUtils;
+import org.apache.stormcrawler.util.URLUtil;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -46,30 +72,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
-import org.apache.storm.Config;
-import org.apache.storm.task.OutputCollector;
-import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.OutputFieldsDeclarer;
-import org.apache.storm.tuple.Fields;
-import org.apache.storm.tuple.Tuple;
-import org.apache.storm.tuple.Values;
-import org.apache.storm.utils.TupleUtils;
-import org.apache.storm.utils.Utils;
-import org.apache.stormcrawler.Constants;
-import org.apache.stormcrawler.Metadata;
-import org.apache.stormcrawler.metrics.CrawlerMetrics;
-import org.apache.stormcrawler.metrics.ScopedCounter;
-import org.apache.stormcrawler.metrics.ScopedReducedMetric;
-import org.apache.stormcrawler.persistence.Status;
-import org.apache.stormcrawler.protocol.Protocol;
-import org.apache.stormcrawler.protocol.ProtocolFactory;
-import org.apache.stormcrawler.protocol.ProtocolResponse;
-import org.apache.stormcrawler.protocol.RobotRules;
-import org.apache.stormcrawler.util.ConfUtils;
-import org.apache.stormcrawler.util.URLUtil;
-import org.slf4j.LoggerFactory;
 
 /**
  * A multithreaded, queue-based fetcher adapted from Apache Nutch. Enforces the politeness and
@@ -172,22 +174,26 @@ public class FetcherBolt extends StatusEmitterBolt {
                 return new FetchItem(url, t, queueId);
             }
 
+            // one canonical host for all queue modes: aliases of one server
+            // (percent-escaping, case, trailing dot) must share a queue
+            final String canonicalHost = URLUtil.getCanonicalHost(u);
+
             if (FetchItemQueues.QUEUE_MODE_IP.equalsIgnoreCase(queueMode)) {
                 try {
-                    final InetAddress addr = InetAddress.getByName(u.getHost());
+                    final InetAddress addr = InetAddress.getByName(canonicalHost);
                     key = addr.getHostAddress();
                 } catch (final UnknownHostException e) {
-                    LOG.warn("Unable to resolve IP for {}, using hostname as key.", u.getHost());
-                    key = u.getHost();
+                    LOG.warn("Unable to resolve IP for {}, using hostname as key.", canonicalHost);
+                    key = canonicalHost;
                 }
             } else if (FetchItemQueues.QUEUE_MODE_DOMAIN.equalsIgnoreCase(queueMode)) {
-                key = PaidLevelDomain.getPLD(u.getHost());
+                key = PaidLevelDomain.getPLD(canonicalHost);
                 if (key == null) {
                     LOG.warn("Unknown domain for url: {}, using hostname as key", url);
-                    key = u.getHost();
+                    key = canonicalHost;
                 }
             } else {
-                key = URLUtil.getCanonicalHost(u);
+                key = canonicalHost;
             }
 
             if (key == null) {
@@ -496,7 +502,8 @@ public class FetcherBolt extends StatusEmitterBolt {
                         delay = Long.parseLong(v);
                     } catch (NumberFormatException e) {
                         LOG.warn(
-                                "Invalid crawl delay value '{}' in metadata for queue '{}', using default.",
+                                "Invalid crawl delay value '{}' in metadata for queue '{}', using"
+                                    + " default.",
                                 v,
                                 id);
                     }
@@ -508,7 +515,8 @@ public class FetcherBolt extends StatusEmitterBolt {
                         minDelay = Long.parseLong(v);
                     } catch (NumberFormatException e) {
                         LOG.warn(
-                                "Invalid min crawl delay value '{}' in metadata for queue '{}', using default.",
+                                "Invalid min crawl delay value '{}' in metadata for queue '{}',"
+                                    + " using default.",
                                 v,
                                 id);
                     }
@@ -541,7 +549,8 @@ public class FetcherBolt extends StatusEmitterBolt {
                                             threadVal = Integer.parseInt(val);
                                         } catch (NumberFormatException e) {
                                             LOG.warn(
-                                                    "Invalid max threads value '{}' in metadata for queue '{}', using default.",
+                                                    "Invalid max threads value '{}' in metadata for queue '{}',"
+                                                        + " using default.",
                                                     val,
                                                     k);
                                         }

--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -501,7 +501,7 @@ public class FetcherBolt extends StatusEmitterBolt {
                     } catch (NumberFormatException e) {
                         LOG.warn(
                                 "Invalid crawl delay value '{}' in metadata for queue '{}', using"
-                                    + " default.",
+                                        + " default.",
                                 v,
                                 id);
                     }
@@ -514,7 +514,7 @@ public class FetcherBolt extends StatusEmitterBolt {
                     } catch (NumberFormatException e) {
                         LOG.warn(
                                 "Invalid min crawl delay value '{}' in metadata for queue '{}',"
-                                    + " using default.",
+                                        + " using default.",
                                 v,
                                 id);
                     }
@@ -548,7 +548,7 @@ public class FetcherBolt extends StatusEmitterBolt {
                                         } catch (NumberFormatException e) {
                                             LOG.warn(
                                                     "Invalid max threads value '{}' in metadata for queue '{}',"
-                                                        + " using default.",
+                                                            + " using default.",
                                                     val,
                                                     k);
                                         }

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -628,7 +628,7 @@ public class SimpleFetcherBolt extends StatusEmitterBolt {
                 key = u.getHost();
             }
         } else {
-            key = u.getHost();
+            key = URLUtil.getCanonicalHost(u);
             if (key == null) {
                 LOG.warn("Unknown host for url: {}, using URL string as key", u.toExternalForm());
                 key = u.toExternalForm();

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -19,10 +19,23 @@ package org.apache.stormcrawler.bolt;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-
 import crawlercommons.domains.PaidLevelDomain;
 import crawlercommons.robots.BaseRobotRules;
-
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.storm.Config;
@@ -46,22 +59,6 @@ import org.apache.stormcrawler.protocol.RobotRules;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
-
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A simple fetcher with no internal queues. This bolt either enforces the delay set by the

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -19,23 +19,10 @@ package org.apache.stormcrawler.bolt;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+
 import crawlercommons.domains.PaidLevelDomain;
 import crawlercommons.robots.BaseRobotRules;
-import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.UnknownHostException;
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-import java.util.Map;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.storm.Config;
@@ -59,6 +46,22 @@ import org.apache.stormcrawler.protocol.RobotRules;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A simple fetcher with no internal queues. This bolt either enforces the delay set by the
@@ -612,23 +615,26 @@ public class SimpleFetcherBolt extends StatusEmitterBolt {
 
     private String getPolitenessKey(URL u) {
         String key;
+        // one canonical host for all queue modes: aliases of one server
+        // (percent-escaping, case, trailing dot) must share a queue
+        final String canonicalHost = URLUtil.getCanonicalHost(u);
         if (QUEUE_MODE_IP.equalsIgnoreCase(queueMode)) {
             try {
-                final InetAddress addr = InetAddress.getByName(u.getHost());
+                final InetAddress addr = InetAddress.getByName(canonicalHost);
                 key = addr.getHostAddress();
             } catch (final UnknownHostException e) {
                 // unable to resolve it, so don't fall back to host name
-                LOG.warn("Unable to resolve: {}, skipping.", u.getHost());
+                LOG.warn("Unable to resolve: {}, skipping.", canonicalHost);
                 return null;
             }
         } else if (QUEUE_MODE_DOMAIN.equalsIgnoreCase(queueMode)) {
-            key = PaidLevelDomain.getPLD(u.getHost());
+            key = PaidLevelDomain.getPLD(canonicalHost);
             if (key == null) {
                 LOG.warn("Unknown domain for url: {}, using hostname as key", u.toExternalForm());
-                key = u.getHost();
+                key = canonicalHost;
             }
         } else {
-            key = URLUtil.getCanonicalHost(u);
+            key = canonicalHost;
             if (key == null) {
                 LOG.warn("Unknown host for url: {}, using URL string as key", u.toExternalForm());
                 key = u.toExternalForm();

--- a/core/src/main/java/org/apache/stormcrawler/bolt/URLPartitionerBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/URLPartitionerBolt.java
@@ -85,7 +85,9 @@ public class URLPartitionerBolt extends BaseRichBolt {
             URL u;
             try {
                 u = URLUtil.toURL(url);
-                host = u.getHost();
+                // canonical host so that aliases of one server (percent-escaping, case, trailing
+                // dot) get the same partition key as the one the fetcher will queue them under
+                host = URLUtil.getCanonicalHost(u);
             } catch (MalformedURLException e1) {
                 eventCounter.scope("Invalid URL").incrBy(1);
                 LOG.warn("Invalid URL: {}", url);

--- a/core/src/main/java/org/apache/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/persistence/AbstractStatusUpdaterBolt.java
@@ -39,6 +39,7 @@ import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.metrics.CrawlerMetrics;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.apache.stormcrawler.util.MetadataTransfer;
+import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +73,15 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
     public static String roundDateParamName = "status.updater.unit.round.date";
 
     /**
+     * Parameter name for normalising the host component of discovered URLs before they are stored.
+     * Aliases of one server (percent-escaping, case, trailing dot) end up as one record in the
+     * store, one politeness queue and one robots.txt cache entry. False by default: the document id
+     * is a hash of the URL, so enabling this after URLs have been stored in raw form makes those
+     * servers re-discover their aliases under the normalised form as a second, bounded record.
+     */
+    public static String normaliseHostsParamName = "status.updater.normalise.hosts";
+
+    /**
      * Key used to pass a preset Date to use as nextFetchDate. The value must represent a valid
      * instant in UTC and be parsable using {@link DateTimeFormatter#ISO_INSTANT}. This also
      * indicates that the storage can be done directly on the metadata as-is.
@@ -88,6 +98,8 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
     private boolean useCache = true;
 
     private int maxFetchErrors = 3;
+
+    private boolean normaliseHosts = false;
 
     private long cacheHits = 0;
     private long cacheMisses = 0;
@@ -135,6 +147,8 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
 
         maxFetchErrors = ConfUtils.getInt(stormConf, maxFetchErrorsParamName, 3);
 
+        normaliseHosts = ConfUtils.getBoolean(stormConf, normaliseHostsParamName, false);
+
         String tmpdateround = ConfUtils.getString(stormConf, roundDateParamName, "SECOND");
         if (tmpdateround.equalsIgnoreCase("MINUTE")) {
             roundDateUnit = Calendar.MINUTE;
@@ -150,6 +164,18 @@ public abstract class AbstractStatusUpdaterBolt extends BaseRichBolt {
         Status status = (Status) tuple.getValueByField("status");
 
         boolean potentiallyNew = status.equals(Status.DISCOVERED);
+
+        // the one write path into the store: normalise the host of
+        // discovered URLs so that aliases of one server reach the backend,
+        // the dedup cache below and the politeness queues as one record.
+        // Only done for DISCOVERED: the other statuses carry URLs which
+        // came out of the store already normalised (when the flag is on),
+        // so re-normalising them would be wasted work on the hot path.
+        // Before the cache lookup and the as-is early return, so those see
+        // the same key the store will be written under.
+        if (potentiallyNew && normaliseHosts) {
+            url = URLUtil.normaliseHost(url);
+        }
 
         // if the URL is a freshly discovered one
         // check whether it is already known in the cache

--- a/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/HttpRobotRulesParser.java
@@ -105,7 +105,12 @@ public class HttpRobotRulesParser extends RobotRulesParser {
     /** Compose unique key to store and access robot rules in cache for given URL. */
     protected static String getCacheKey(URL url) {
         String protocol = url.getProtocol().toLowerCase(Locale.ROOT);
-        String host = url.getHost().toLowerCase(Locale.ROOT);
+        // canonicalise the host so aliases of one server (percent-escaping,
+        // case, trailing dot) share one cache entry and one robots.txt fetch
+        String host = URLUtil.getCanonicalHost(url);
+        if (host == null) {
+            host = "";
+        }
 
         int port = url.getPort();
         if (port == -1) {

--- a/core/src/main/java/org/apache/stormcrawler/util/URLPartitioner.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/URLPartitioner.java
@@ -59,7 +59,9 @@ public class URLPartitioner {
             URL u;
             try {
                 u = URLUtil.toURL(url);
-                host = u.getHost();
+                // canonical host so that aliases of one server (percent-escaping, case, trailing
+                // dot) get the same partition key as the one the fetcher will queue them under
+                host = URLUtil.getCanonicalHost(u);
             } catch (MalformedURLException e) {
                 LOG.warn("Invalid URL: {}", url);
                 return null;

--- a/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
@@ -22,6 +22,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.regex.Matcher;
@@ -251,6 +252,31 @@ public class URLUtil {
         } catch (MalformedURLException e) {
             return null;
         }
+    }
+
+    /**
+     * Returns the host in the form the HTTP client will connect to it: percent-escapes decoded,
+     * lowercased and without a trailing dot. Host strings which only differ in escaping or case
+     * reach the same server, so politeness queues and robots.txt caches must key on the same
+     * value, otherwise one server is fetched under several queue ids and its robots.txt is
+     * downloaded once per spelling.
+     *
+     * @param url The url to check.
+     * @return String The canonical host for the url, or null if the url is not well formed or has
+     *     no host.
+     */
+    public static String getCanonicalHost(URL url) {
+        String host = url.getHost();
+        if (host == null) {
+            return null;
+        }
+        // okhttp percent-decodes the host when it parses the URL; do the same
+        // so keys derived from the URL string agree with what it connects to
+        String decoded = URLDecoder.decode(host, StandardCharsets.UTF_8);
+        if (decoded.endsWith(".")) {
+            decoded = decoded.substring(0, decoded.length() - 1);
+        }
+        return decoded.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
@@ -308,6 +308,81 @@ public class URLUtil {
     }
 
     /**
+     * Returns the url with its host replaced by {@link #getCanonicalHost(URL)}: percent-escapes
+     * decoded, lowercased and without a trailing dot. Only the authority changes; everything else
+     * in the url is kept byte for byte. Host aliases of one server therefore end up as one record
+     * in the status store, one politeness queue and one robots.txt cache entry, but two different
+     * urls stay two different urls. The url is returned unchanged when it has no host, cannot be
+     * parsed, or is already canonical.
+     *
+     * @param url The url to normalise.
+     * @return String The url with a canonical host, or the input unchanged.
+     */
+    public static String normaliseHost(String url) {
+        try {
+            URL u = toURL(url);
+            String host = u.getHost();
+            if (host == null || host.isEmpty() || host.startsWith("[")) {
+                // no host, or an IPv6 literal: nothing to collapse, leave as is
+                return url;
+            }
+            String canonical = getCanonicalHost(u);
+            if (canonical == null || canonical.equals(host)) {
+                return url;
+            }
+            // the host never contains characters which would end the authority
+            // (":", "/", "?", "#", "@" are all illegal in a host); a decoded
+            // escape which produced one of them leaves the url unchanged
+            if (canonical.indexOf(':') >= 0
+                    || canonical.indexOf('/') >= 0
+                    || canonical.indexOf('?') >= 0
+                    || canonical.indexOf('#') >= 0
+                    || canonical.indexOf('@') >= 0) {
+                return url;
+            }
+            // splice the canonical host back into the original string, keeping
+            // the scheme, any user info, the port and everything after the
+            // authority exactly as they were
+            int schemeEnd = url.indexOf("//");
+            if (schemeEnd < 0) {
+                return url;
+            }
+            int authorityStart = schemeEnd + 2;
+            // the host part starts after the user info
+            int at = url.lastIndexOf('@', indexOfAuthorityEnd(url, authorityStart));
+            int hostStart = Math.max(at + 1, authorityStart);
+            int hostEnd = indexOfHostEnd(url, hostStart);
+            if (hostEnd < 0) {
+                return url;
+            }
+            return url.substring(0, hostStart) + canonical + url.substring(hostEnd);
+        } catch (MalformedURLException | IllegalArgumentException e) {
+            return url;
+        }
+    }
+
+    /** Index of the end of the authority of a URL string starting at pos. */
+    private static int indexOfAuthorityEnd(String url, int pos) {
+        for (int i = pos; i < url.length(); i++) {
+            char c = url.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                return i;
+            }
+        }
+        return url.length();
+    }
+
+    /**
+     * Index just after the host part of an authority: hosts never contain ':', so the first colon
+     * after the host starts the port, and "/", "?" or "#" end the authority.
+     */
+    private static int indexOfHostEnd(String url, int hostStart) {
+        int authorityEnd = indexOfAuthorityEnd(url, hostStart);
+        int colon = url.indexOf(':', hostStart);
+        return colon == -1 || colon >= authorityEnd ? authorityEnd : colon;
+    }
+
+    /**
      * Returns the page for the url. The page consists of the protocol, host, and path, but does not
      * include the query string. The host is lowercased but the path is not.
      *

--- a/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
@@ -255,11 +255,11 @@ public class URLUtil {
     }
 
     /**
-     * Returns the host in the form the HTTP client will connect to it: percent-escapes decoded,
-     * lowercased and without a trailing dot. Host strings which only differ in escaping or case
-     * reach the same server, so politeness queues and robots.txt caches must key on the same
-     * value, otherwise one server is fetched under several queue ids and its robots.txt is
-     * downloaded once per spelling.
+     * Returns the form of the host used to key politeness queues and the robots.txt cache: what
+     * okhttp connects to, with the root label normalised away. Host strings which only differ in
+     * escaping or case reach the same server, so both spellings must end up under one key,
+     * otherwise one server is fetched under several queue ids and its robots.txt is downloaded once
+     * per spelling.
      *
      * @param url The url to check.
      * @return String The canonical host for the url, or null if the url is not well formed or has
@@ -271,12 +271,40 @@ public class URLUtil {
             return null;
         }
         // okhttp percent-decodes the host when it parses the URL; do the same
-        // so keys derived from the URL string agree with what it connects to
-        String decoded = URLDecoder.decode(host, StandardCharsets.UTF_8);
+        // so keys derived from the URL string agree with what it connects to.
+        // The decoder never throws: crawled content is hostile input, and a
+        // malformed escape falls back to the raw spelling rather than blowing
+        // up the caller
+        String decoded = percentDecodeHost(host);
         if (decoded.endsWith(".")) {
             decoded = decoded.substring(0, decoded.length() - 1);
         }
         return decoded.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * Percent-decodes a host string, leaving {@code +} alone and keeping malformed escapes as
+     * literal characters. Unlike {@link URLDecoder#decode}, this never throws.
+     */
+    private static String percentDecodeHost(String host) {
+        if (!host.contains("%")) {
+            return host;
+        }
+        StringBuilder sb = new StringBuilder(host.length());
+        for (int i = 0; i < host.length(); i++) {
+            char c = host.charAt(i);
+            if (c == '%' && i + 2 < host.length()) {
+                int hi = Character.digit(host.charAt(i + 1), 16);
+                int lo = Character.digit(host.charAt(i + 2), 16);
+                if (hi != -1 && lo != -1) {
+                    sb.append((char) ((hi << 4) | lo));
+                    i += 2;
+                    continue;
+                }
+            }
+            sb.append(c);
+        }
+        return sb.toString();
     }
 
     /**

--- a/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
+++ b/core/src/main/java/org/apache/stormcrawler/util/URLUtil.java
@@ -284,27 +284,33 @@ public class URLUtil {
 
     /**
      * Percent-decodes a host string, leaving {@code +} alone and keeping malformed escapes as
-     * literal characters. Unlike {@link URLDecoder#decode}, this never throws.
+     * literal characters. The decoded octets are interpreted as UTF-8, so a multi-byte sequence
+     * like {@code %C3%BC} becomes one character ({@code ü}) rather than one character per octet.
+     * Unlike {@link URLDecoder#decode}, this never throws.
      */
     private static String percentDecodeHost(String host) {
         if (!host.contains("%")) {
             return host;
         }
-        StringBuilder sb = new StringBuilder(host.length());
+        java.io.ByteArrayOutputStream bytes = new java.io.ByteArrayOutputStream(host.length());
         for (int i = 0; i < host.length(); i++) {
             char c = host.charAt(i);
             if (c == '%' && i + 2 < host.length()) {
                 int hi = Character.digit(host.charAt(i + 1), 16);
                 int lo = Character.digit(host.charAt(i + 2), 16);
                 if (hi != -1 && lo != -1) {
-                    sb.append((char) ((hi << 4) | lo));
+                    bytes.write((hi << 4) | lo);
                     i += 2;
                     continue;
                 }
             }
-            sb.append(c);
+            // a literal character: encode it as UTF-8 so it interleaves correctly
+            // with the decoded octets (hosts are ASCII in practice, but a raw
+            // non-ASCII label must not be mangled)
+            byte[] encoded = String.valueOf(c).getBytes(StandardCharsets.UTF_8);
+            bytes.write(encoded, 0, encoded.length);
         }
-        return sb.toString();
+        return new String(bytes.toByteArray(), StandardCharsets.UTF_8);
     }
 
     /**

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -333,6 +333,14 @@ config:
   status.updater.use.cache: true
   status.updater.cache.spec: "expireAfterAccess=1h,softValues"
 
+  # Normalise the host component of DISCOVERED URLs before they are stored,
+  # so that aliases of one server (percent-escaping, case, trailing dot)
+  # become a single record, a single politeness queue and a single robots.txt
+  # fetch. Off by default: document ids are hashed from the URL, so turning
+  # this on makes servers whose aliases were already stored in raw form be
+  # re-discovered under the normalised form as a second, bounded record.
+  status.updater.normalise.hosts: false
+
   # Can also take "MINUTE" or "HOUR"
   status.updater.unit.round.date: "SECOND"
 

--- a/core/src/test/java/org/apache/stormcrawler/bolt/URLPartitionerBoltTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/URLPartitionerBoltTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.storm.task.OutputCollector;
 import org.apache.stormcrawler.Constants;
-import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.TestUtil;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.junit.jupiter.api.Assertions;
@@ -32,8 +31,8 @@ import org.mockito.Mockito;
 
 /**
  * Regression coverage for the partitioner-to-fetcher path: the key the partitioner bolt emits must
- * be identical for host aliases (percent-escaping, trailing dot, case), otherwise the fetcher
- * opens one politeness queue per spelling.
+ * be identical for host aliases (percent-escaping, trailing dot, case), otherwise the fetcher opens
+ * one politeness queue per spelling.
  */
 class URLPartitionerBoltTest {
 
@@ -70,8 +69,7 @@ class URLPartitionerBoltTest {
                         Constants.PARTITION_MODEParamName,
                         Constants.PARTITION_MODE_HOST),
                 Constants.PARTITION_MODE_HOST);
-        Assertions.assertEquals(
-                keyFor("http://example.org/a"), keyFor("http://exampl%65.org/a"));
+        Assertions.assertEquals(keyFor("http://example.org/a"), keyFor("http://exampl%65.org/a"));
         Assertions.assertEquals(keyFor("http://example.org/a"), keyFor("http://example.org./a"));
         Assertions.assertEquals(keyFor("http://example.org/a"), keyFor("http://EXAMPLE.org/a"));
     }

--- a/core/src/test/java/org/apache/stormcrawler/bolt/URLPartitionerBoltTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/URLPartitionerBoltTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.bolt;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.storm.task.OutputCollector;
+import org.apache.stormcrawler.Constants;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.TestUtil;
+import org.apache.stormcrawler.util.ConfUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/**
+ * Regression coverage for the partitioner-to-fetcher path: the key the partitioner bolt emits must
+ * be identical for host aliases (percent-escaping, trailing dot, case), otherwise the fetcher
+ * opens one politeness queue per spelling.
+ */
+class URLPartitionerBoltTest {
+
+    private OutputCollector collector;
+
+    private URLPartitionerBolt bolt;
+
+    @BeforeEach
+    void setUp() {
+        collector = Mockito.mock(OutputCollector.class);
+        bolt = new URLPartitionerBolt();
+        Map<String, Object> conf = new HashMap<>();
+        bolt.prepare(conf, TestUtil.getMockedTopologyContext(), collector);
+    }
+
+    private String keyFor(String url) {
+        Mockito.reset(collector);
+        org.apache.storm.tuple.Tuple tuple = Mockito.mock(org.apache.storm.tuple.Tuple.class);
+        Mockito.when(tuple.contains("metadata")).thenReturn(false);
+        Mockito.when(tuple.getStringByField("url")).thenReturn(url);
+        bolt.execute(tuple);
+        ArgumentCaptor<org.apache.storm.tuple.Values> captor =
+                ArgumentCaptor.forClass(org.apache.storm.tuple.Values.class);
+        Mockito.verify(collector).emit(Mockito.eq(tuple), captor.capture());
+        return (String) captor.getValue().get(1);
+    }
+
+    /** The shipped default partition mode is byHost. */
+    @Test
+    void byHostIsTheDefaultAndCollapsesAliases() {
+        Assertions.assertEquals(
+                ConfUtils.getString(
+                        Map.of(Constants.PARTITION_MODEParamName, Constants.PARTITION_MODE_HOST),
+                        Constants.PARTITION_MODEParamName,
+                        Constants.PARTITION_MODE_HOST),
+                Constants.PARTITION_MODE_HOST);
+        Assertions.assertEquals(
+                keyFor("http://example.org/a"), keyFor("http://exampl%65.org/a"));
+        Assertions.assertEquals(keyFor("http://example.org/a"), keyFor("http://example.org./a"));
+        Assertions.assertEquals(keyFor("http://example.org/a"), keyFor("http://EXAMPLE.org/a"));
+    }
+
+    /** The URL itself is not rewritten - only the key derived from it is canonicalised. */
+    @Test
+    void urlIsEmittedUnchanged() {
+        Mockito.reset(collector);
+        org.apache.storm.tuple.Tuple tuple = Mockito.mock(org.apache.storm.tuple.Tuple.class);
+        Mockito.when(tuple.contains("metadata")).thenReturn(false);
+        Mockito.when(tuple.getStringByField("url")).thenReturn("http://exampl%65.org/a");
+        bolt.execute(tuple);
+        ArgumentCaptor<org.apache.storm.tuple.Values> captor =
+                ArgumentCaptor.forClass(org.apache.storm.tuple.Values.class);
+        Mockito.verify(collector).emit(Mockito.eq(tuple), captor.capture());
+        Assertions.assertEquals("http://exampl%65.org/a", captor.getValue().get(0));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/persistence/AbstractStatusUpdaterBoltTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/persistence/AbstractStatusUpdaterBoltTest.java
@@ -47,12 +47,14 @@ class AbstractStatusUpdaterBoltTest {
     private static class RecordingStatusUpdaterBolt extends AbstractStatusUpdaterBolt {
 
         Optional<Date> nextFetch;
+        String storedUrl;
         int stored = 0;
 
         @Override
         public void store(
                 String url, Status status, Metadata metadata, Optional<Date> nextFetch, Tuple t) {
             this.nextFetch = nextFetch;
+            this.storedUrl = url;
             this.stored++;
             ack(t, url);
         }
@@ -118,5 +120,67 @@ class AbstractStatusUpdaterBoltTest {
 
         assertEquals(1, bolt.stored, "the URL must still be stored");
         assertNotNull(bolt.nextFetch);
+    }
+
+    /** A bolt prepared with the given normalise-hosts and cache settings. */
+    private static RecordingStatusUpdaterBolt newBolt(boolean normaliseHosts, boolean useCache) {
+        RecordingStatusUpdaterBolt b = new RecordingStatusUpdaterBolt();
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(AbstractStatusUpdaterBolt.useCacheParamName, useCache);
+        conf.put(AbstractStatusUpdaterBolt.normaliseHostsParamName, normaliseHosts);
+        conf.put(
+                AbstractStatusUpdaterBolt.cacheConfigParamName,
+                "maximumSize=100,expireAfterAccess=1h");
+        conf.put(Scheduler.schedulerClassParamName, DefaultScheduler.class.getName());
+        conf.put(MetadataTransfer.metadataTransferClassParamName, MetadataTransfer.class.getName());
+        b.prepare(conf, TestUtil.getMockedTopologyContext(), mock(OutputCollector.class));
+        return b;
+    }
+
+    private static Tuple discoveredTuple(String url) {
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getStringByField("url")).thenReturn(url);
+        when(tuple.getValueByField("metadata")).thenReturn(new Metadata());
+        when(tuple.getValueByField("status")).thenReturn(Status.DISCOVERED);
+        return tuple;
+    }
+
+    @Test
+    void discoveredHostIsNormalisedWhenEnabled() {
+        RecordingStatusUpdaterBolt b = newBolt(true, false);
+        b.execute(discoveredTuple("http://exampl%65.org./a"));
+        assertEquals("http://example.org/a", b.storedUrl, "the aliased host is stored normalised");
+    }
+
+    /** The dedup cache is keyed on the normalised URL, so aliases collapse. */
+    @Test
+    void normalisedAliasesHitTheDedupCache() {
+        RecordingStatusUpdaterBolt b = newBolt(true, true);
+        b.execute(discoveredTuple("http://example.org/a"));
+        b.execute(discoveredTuple("http://exampl%65.org/a"));
+        assertEquals(1, b.stored, "the second spelling is deduped against the first");
+    }
+
+    @Test
+    void discoveredHostIsLeftRawWhenDisabled() {
+        RecordingStatusUpdaterBolt b = newBolt(false, false);
+        b.execute(discoveredTuple("http://exampl%65.org./a"));
+        assertEquals(
+                "http://exampl%65.org./a", b.storedUrl, "the default keeps the URL byte for byte");
+    }
+
+    /** Only DISCOVERED is normalised; updates of stored URLs are not rewritten. */
+    @Test
+    void onlyDiscoveredStatusIsNormalised() {
+        RecordingStatusUpdaterBolt b = newBolt(true, false);
+        Tuple tuple = mock(Tuple.class);
+        when(tuple.getStringByField("url")).thenReturn("http://exampl%65.org/a");
+        when(tuple.getValueByField("metadata")).thenReturn(new Metadata());
+        when(tuple.getValueByField("status")).thenReturn(Status.FETCHED);
+        b.execute(tuple);
+        assertEquals(
+                "http://exampl%65.org/a",
+                b.storedUrl,
+                "a FETCHED update carries a URL read back from the store and is not rewritten");
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/protocol/HostAliasCacheKeyTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/HostAliasCacheKeyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.protocol;
+
+import java.net.URL;
+import okhttp3.HttpUrl;
+import org.apache.stormcrawler.util.URLUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Two URLs whose host strings differ only by percent-escaping or by a trailing dot are sent to the
+ * same server by okhttp, so they must share one robots.txt cache entry and one politeness queue.
+ */
+class HostAliasCacheKeyTest {
+
+    @Test
+    void okhttpCollapsesHostAliases() {
+        // what the client actually connects to; okhttp percent-decodes and
+        // lowercases the host but keeps a trailing dot (as the JDK does)
+        Assertions.assertEquals(
+                "example.org", HttpUrl.parse("http://%65xample.org/a").host(), "percent-escaped");
+        Assertions.assertEquals(
+                "example.org", HttpUrl.parse("http://exampl%65.org/a").host(), "percent-escaped");
+        Assertions.assertEquals(
+                "example.org", HttpUrl.parse("http://EXAMPLE.org/a").host(), "upper case");
+        Assertions.assertEquals(
+                "example.org.", HttpUrl.parse("http://example.org./a").host(), "trailing dot");
+    }
+
+    @Test
+    void canonicalHostMatchesWhatOkHttpConnectsTo() throws Exception {
+        Assertions.assertEquals(
+                HttpUrl.parse("http://exampl%65.org/a").host(),
+                URLUtil.getCanonicalHost(new URL("http://exampl%65.org/a")));
+        Assertions.assertEquals(
+                "example.org", URLUtil.getCanonicalHost(new URL("http://example.org./a")));
+        Assertions.assertEquals(
+                "example.org", URLUtil.getCanonicalHost(new URL("http://EXAMPLE.org/a")));
+    }
+
+    @Test
+    void robotsCacheKeyIsTheSameForHostAliases() throws Exception {
+        String canonical = HttpRobotRulesParser.getCacheKey(new URL("http://example.org/a"));
+        Assertions.assertEquals(
+                canonical, HttpRobotRulesParser.getCacheKey(new URL("http://exampl%65.org/a")));
+        Assertions.assertEquals(
+                canonical, HttpRobotRulesParser.getCacheKey(new URL("http://example.org./a")));
+        Assertions.assertEquals(
+                canonical, HttpRobotRulesParser.getCacheKey(new URL("http://EXAMPLE.org/a")));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/util/URLPartitionerTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/URLPartitionerTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
- * Host aliases of one server (percent-escaping, case, trailing dot) must get the same partition
- * key in every mode, otherwise they end up in separate politeness queues.
+ * Host aliases of one server (percent-escaping, case, trailing dot) must get the same partition key
+ * in every mode, otherwise they end up in separate politeness queues.
  */
 class URLPartitionerTest {
 

--- a/core/src/test/java/org/apache/stormcrawler/util/URLPartitionerTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/URLPartitionerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.util;
+
+import org.apache.stormcrawler.Constants;
+import org.apache.stormcrawler.Metadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Host aliases of one server (percent-escaping, case, trailing dot) must get the same partition
+ * key in every mode, otherwise they end up in separate politeness queues.
+ */
+class URLPartitionerTest {
+
+    private static final Metadata EMPTY = new Metadata();
+
+    @Test
+    void byHostCollapsesHostAliases() {
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://example.org/a", EMPTY, Constants.PARTITION_MODE_HOST));
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://exampl%65.org/a", EMPTY, Constants.PARTITION_MODE_HOST));
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://example.org./a", EMPTY, Constants.PARTITION_MODE_HOST));
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://EXAMPLE.org/a", EMPTY, Constants.PARTITION_MODE_HOST));
+    }
+
+    @Test
+    void byDomainCollapsesHostAliases() {
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://example.org/a", EMPTY, Constants.PARTITION_MODE_DOMAIN));
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://exampl%65.org/a", EMPTY, Constants.PARTITION_MODE_DOMAIN));
+        Assertions.assertEquals(
+                "example.org",
+                URLPartitioner.getPartition(
+                        "http://www.example.org./a", EMPTY, Constants.PARTITION_MODE_DOMAIN));
+    }
+
+    @Test
+    void byIPCollapsesHostAliases() {
+        String canonical =
+                URLPartitioner.getPartition(
+                        "http://example.org/a", EMPTY, Constants.PARTITION_MODE_IP);
+        Assertions.assertNotNull(canonical);
+        Assertions.assertEquals(
+                canonical,
+                URLPartitioner.getPartition(
+                        "http://exampl%65.org/a", EMPTY, Constants.PARTITION_MODE_IP));
+        Assertions.assertEquals(
+                canonical,
+                URLPartitioner.getPartition(
+                        "http://example.org./a", EMPTY, Constants.PARTITION_MODE_IP));
+    }
+
+    /** An explicitly supplied IP is used as the key unchanged, whatever the URL spells. */
+    @Test
+    void byIPKeepsProvidedIP() {
+        Metadata metadata = new Metadata();
+        metadata.setValue("ip", "192.0.2.1");
+        Assertions.assertEquals(
+                "192.0.2.1",
+                URLPartitioner.getPartition(
+                        "http://exampl%65.org/a", metadata, Constants.PARTITION_MODE_IP));
+        Assertions.assertEquals(
+                "192.0.2.1",
+                URLPartitioner.getPartition(
+                        "http://example.org./a", metadata, Constants.PARTITION_MODE_IP));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/util/URLUtilNormaliseHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/URLUtilNormaliseHostTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/** Host aliases collapse to one url; different urls stay different. */
+class URLUtilNormaliseHostTest {
+
+    @Test
+    void percentEscapedHostIsDecoded() {
+        Assertions.assertEquals(
+                "http://example.org/a?x=1", URLUtil.normaliseHost("http://exampl%65.org/a?x=1"));
+        Assertions.assertEquals(
+                "http://example.org/a?x=1", URLUtil.normaliseHost("http://%65xample.org/a?x=1"));
+    }
+
+    @Test
+    void caseAndTrailingDotAreNormalised() {
+        Assertions.assertEquals(
+                "http://example.org/p", URLUtil.normaliseHost("http://EXAMPLE.org/p"));
+        Assertions.assertEquals(
+                "http://example.org/p", URLUtil.normaliseHost("http://example.org./p"));
+    }
+
+    /** The userinfo and the port are kept, only the host is replaced. */
+    @Test
+    void userInfoAndPortPreserved() {
+        Assertions.assertEquals(
+                "http://user:pw@example.org:8080/x",
+                URLUtil.normaliseHost("http://user:pw@Exampl%65.org:8080/x"));
+    }
+
+    /** Already-canonical, hostless, IPv6 and non-hierarchical urls are unchanged. */
+    @Test
+    void leavesOtherUrlsUnchanged() {
+        Assertions.assertEquals(
+                "http://example.org/a", URLUtil.normaliseHost("http://example.org/a"));
+        Assertions.assertEquals("file:///etc/passwd", URLUtil.normaliseHost("file:///etc/passwd"));
+        Assertions.assertEquals("http://[::1]/x", URLUtil.normaliseHost("http://[::1]/x"));
+        Assertions.assertEquals("mailto:a@b.c", URLUtil.normaliseHost("mailto:a@b.c"));
+        Assertions.assertEquals("not a url", URLUtil.normaliseHost("not a url"));
+    }
+
+    /** A decoded escape which would corrupt the authority leaves the url alone. */
+    @Test
+    void escapesToAuthorityDelimitersAreIgnored() {
+        // %3A decodes to a colon, which must not end up inside the host
+        Assertions.assertEquals(
+                "http://ex%3Aample.org/", URLUtil.normaliseHost("http://ex%3Aample.org/"));
+    }
+
+    @Test
+    void normalisationIsIdempotent() {
+        String once = URLUtil.normaliseHost("http://exampl%65.org./p");
+        Assertions.assertEquals(once, URLUtil.normaliseHost(once));
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/util/URLUtilNormaliseHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/util/URLUtilNormaliseHostTest.java
@@ -71,4 +71,13 @@ class URLUtilNormaliseHostTest {
         String once = URLUtil.normaliseHost("http://exampl%65.org./p");
         Assertions.assertEquals(once, URLUtil.normaliseHost(once));
     }
+
+    /** A multi-byte escape decodes as UTF-8, not one character per octet. */
+    @Test
+    void multiByteEscapeDecodesAsUtf8() {
+        // %C3%BC is the UTF-8 encoding of u-umlaut
+        Assertions.assertEquals(
+                "http://ünicode.example.org/",
+                URLUtil.normaliseHost("http://%C3%BCnicode.example.org/"));
+    }
 }

--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -351,6 +351,7 @@ that is being calculated by a link:https://github.com/apache/stormcrawler/blob/m
 | status.updater.cache.spec | maximumSize=10000, expireAfterAccess=1h | Cache specification for the status updater.
 | status.updater.unit.round.date | SECOND | Unit for rounding the next fetch date. Can also be MINUTE or HOUR.
 | status.updater.use.cache | true | Whether to use cache to avoid re-persisting URLs.
+| status.updater.normalise.hosts | false | Normalise the host component of discovered URLs (percent-decoded, lowercased, trailing dot removed) so that aliases of one server are stored once, share a politeness queue and a robots.txt fetch. Off by default: document ids are hashed from the URL, so enabling it re-discovers aliases already stored in raw form as a second, bounded record.
 |===
 
 ==== Parsing


### PR DESCRIPTION
Fixes #2082.

okhttp percent-decodes and lowercases the host when it parses the URL, so `http://exampl%65.org/` and `http://example.org/` are one origin at connect time — but the raw host string was keyed for the politeness queue, the robots.txt cache and, once stored, the status record, so one server could be fetched under several queue ids (its per-host delay applied several times in parallel) and its robots.txt downloaded once per spelling. Both spellings also reached the backend as separate records.

Per @jnioche and @rzo1 in review, this is addressed at the one place every URL passes through — the status updater — plus the read paths that must hold up independently of it:

**Store side (new): `AbstractStatusUpdaterBolt`**
- `URLUtil.normaliseHost` percent-decodes (never throwing on a malformed escape and leaving `+` alone), lowercases and strips the trailing root label, replacing only the host so every other byte of the URL is preserved.
- `AbstractStatusUpdaterBolt.execute` normalises the host of `DISCOVERED` URLs before the dedup cache lookup and the as-is next-fetch-date early return, so aliases collapse in the cache, the scheduler and the stored record. Only `DISCOVERED`: the other statuses carry URLs already read back from the store.
- Behind `status.updater.normalise.hosts`, **defaulting to false**. @rzo1's release note: `getDocumentID` hashes the URL, so enabling this makes servers whose aliases were already stored raw get re-discovered under the normalised form as a second, bounded record. One release defaulted off, then the default can flip.

**Read side (kept): politeness queues and the robots.txt cache**
These must collapse aliases even while `status.updater.normalise.hosts` is off (the default) and for URLs that were stored before normalisation existed, so the queue id and the robots cache key still canonicalise the host: `URLUtil.getCanonicalHost` in `FetcherBolt.FetchItem.create`, `SimpleFetcherBolt.getPolitenessKey`, `URLPartitioner`/`URLPartitionerBolt` and `HttpRobotRulesParser.getCacheKey`. @rzo1 noted `byIP`/`byDomain` need a canonical host to resolve/split from either way; the explicit `ip` metadata stays authoritative.

Release note: the partition key is canonical whether or not `status.updater.normalise.hosts` is on, so on upgrade a stored URL whose host carries a trailing dot or a `%XX` escape gets a new key; in OpenSearch (routing) and URLFrontier (queue) its next update lands under the new key next to the old record. Rare and bounded.

**IDN (unicode vs punycode)** is recorded as #2145 — a separate concern from this PR.

Tests: `URLUtilNormaliseHostTest` (escape/case/dot/userinfo+port, hostless/IPv6/non-hierarchical unchanged, idempotence), `AbstractStatusUpdaterBoltTest` (normalised storage, dedup-cache collapse, default-off passthrough, only-DISCOVERED), plus the existing `HostAliasCacheKeyTest`, `URLPartitionerTest` and `URLPartitionerBoltTest`. Full core suite green on the branch.
