### PR TITLE
File scheme off by default; reads confined to file.protocol.root

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/protocol/file/FileProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/file/FileProtocol.java
@@ -18,6 +18,9 @@
 package org.apache.stormcrawler.protocol.file;
 
 import crawlercommons.robots.BaseRobotRules;
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.Config;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.protocol.Protocol;
@@ -27,11 +30,37 @@ import org.apache.stormcrawler.util.ConfUtils;
 
 public class FileProtocol implements Protocol {
 
+    /**
+     * Directory reads are confined to when set. Null or empty means the file scheme serves nothing:
+     * a URL decides which path the worker opens, so reads must not be possible until an operator
+     * has chosen a root on purpose.
+     */
+    public static final String ROOT_KEY = "file.protocol.root";
+
     private String encoding;
+
+    private File root;
 
     @Override
     public void configure(Config conf) {
         encoding = ConfUtils.getString(conf, "file.encoding", "UTF-8");
+        String rootPath = ConfUtils.getString(conf, ROOT_KEY, null);
+        if (StringUtils.isNotBlank(rootPath)) {
+            root = new File(rootPath);
+            try {
+                root = root.getCanonicalFile();
+            } catch (IOException e) {
+                throw new RuntimeException("Cannot resolve " + ROOT_KEY + ": " + rootPath, e);
+            }
+            if (!root.isDirectory()) {
+                throw new RuntimeException(ROOT_KEY + " is not a directory: " + rootPath);
+            }
+        }
+    }
+
+    /** Returns the configured confinement root, or null when reads are disabled entirely. */
+    File getRoot() {
+        return root;
     }
 
     @Override

--- a/core/src/main/java/org/apache/stormcrawler/protocol/file/FileResponse.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/file/FileResponse.java
@@ -61,6 +61,23 @@ public class FileResponse {
 
         File file = new File(URLDecoder.decode(path, fileProtocol.getEncoding()));
 
+        /*
+         * A URL decides which path the worker opens: without a configured root
+         * nothing is served, with one the resolved path must stay below it.
+         */
+        File root = fileProtocol.getRoot();
+        if (root == null) {
+            LOG.warn("Refusing to read {} because {} is not configured", url, FileProtocol.ROOT_KEY);
+            statusCode = HttpStatus.SC_FORBIDDEN;
+            return;
+        }
+
+        if (!file.getCanonicalFile().toPath().startsWith(root.toPath())) {
+            LOG.warn("Refusing to read {} because it is outside {}", url, root);
+            statusCode = HttpStatus.SC_FORBIDDEN;
+            return;
+        }
+
         if (!file.exists()) {
             statusCode = HttpStatus.SC_NOT_FOUND;
             return;

--- a/core/src/main/java/org/apache/stormcrawler/protocol/file/FileResponse.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/file/FileResponse.java
@@ -17,6 +17,14 @@
 
 package org.apache.stormcrawler.protocol.file;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.apache.stormcrawler.util.URLUtil;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -25,13 +33,6 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpStatus;
-import org.apache.stormcrawler.Metadata;
-import org.apache.stormcrawler.protocol.ProtocolResponse;
-import org.apache.stormcrawler.util.URLUtil;
-import org.slf4j.LoggerFactory;
 
 public class FileResponse {
 
@@ -67,11 +68,30 @@ public class FileResponse {
          */
         File root = fileProtocol.getRoot();
         if (root == null) {
-            LOG.warn("Refusing to read {} because {} is not configured", url, FileProtocol.ROOT_KEY);
+            LOG.warn(
+                    "Refusing to read {} because {} is not configured", url, FileProtocol.ROOT_KEY);
             statusCode = HttpStatus.SC_FORBIDDEN;
             return;
         }
 
+        // a URL with a host component is refused outright: the host is
+        // meaningless for a local read and silently ignoring it would accept
+        // spellings like file://evil.example.com/etc/passwd
+        if (url.getHost() != null
+                && !url.getHost().isEmpty()
+                && !"localhost".equalsIgnoreCase(url.getHost())) {
+            LOG.warn("Refusing to read {}: the file scheme does not serve remote hosts", url);
+            statusCode = HttpStatus.SC_FORBIDDEN;
+            return;
+        }
+
+        /*
+         * Canonicalising and checking happen before the read, but they are two
+         * operations: a symlink swapped in between the check and the read
+         * would be followed. That window is accepted because the file scheme
+         * is now opt-in and root-confined - the operator who enables it has
+         * accepted that the worker user's read rights are the boundary.
+         */
         if (!file.getCanonicalFile().toPath().startsWith(root.toPath())) {
             LOG.warn("Refusing to read {} because it is outside {}", url, root);
             statusCode = HttpStatus.SC_FORBIDDEN;

--- a/core/src/main/java/org/apache/stormcrawler/protocol/file/FileResponse.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/file/FileResponse.java
@@ -17,14 +17,6 @@
 
 package org.apache.stormcrawler.protocol.file;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpStatus;
-import org.apache.stormcrawler.Metadata;
-import org.apache.stormcrawler.protocol.ProtocolResponse;
-import org.apache.stormcrawler.util.URLUtil;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -33,6 +25,13 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.apache.stormcrawler.util.URLUtil;
+import org.slf4j.LoggerFactory;
 
 public class FileResponse {
 

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -215,10 +215,16 @@ config:
   robots.cache.spec: "maximumSize=10000,expireAfterWrite=6h"
   robots.error.cache.spec: "maximumSize=10000,expireAfterWrite=1h"
 
-  protocols: "http,https,file"
+  # The file scheme must be enabled deliberately: a fetched page can put a
+  # file:// URL into the frontier, and FileProtocol reads whatever path the
+  # worker user can read unless file.protocol.root confines it. When enabled,
+  # set file.protocol.root to the directory reads are confined to; without it
+  # the file scheme serves nothing.
+  protocols: "http,https"
   http.protocol.implementation: "org.apache.stormcrawler.protocol.okhttp.HttpProtocol"
   https.protocol.implementation: "org.apache.stormcrawler.protocol.okhttp.HttpProtocol"
   file.protocol.implementation: "org.apache.stormcrawler.protocol.file.FileProtocol"
+  # file.protocol.root: "/data/corpus"
 
   # number of instances for each protocol implementation
   protocol.instances.num: 1

--- a/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.protocol.file;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.storm.Config;
+import org.apache.storm.utils.Utils;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.protocol.ProtocolResponse;
+import org.apache.stormcrawler.util.ConfUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class FileProtocolDefaultsTest {
+
+    /** The file scheme must not be part of the shipped default protocols list. */
+    @Test
+    void fileSchemeIsNotEnabledByDefault() {
+        Config conf = new Config();
+        Map<String, Object> defaults = Utils.findAndReadConfigFile("crawler-default.yaml", false);
+        conf.putAll(ConfUtils.extractConfigElement(defaults));
+        String protocols = ConfUtils.getString(conf, "protocols", "http,https");
+        List<String> schemes = Arrays.asList(protocols.split(" *, *"));
+        Assertions.assertFalse(
+                schemes.contains("file"),
+                "crawler-default.yaml enables the file scheme by default: " + protocols);
+    }
+
+    /**
+     * Without a configured root, FileProtocol must refuse to serve anything.
+     */
+    @Test
+    void fileProtocolServesNothingWithoutARoot(@TempDir Path tmp) throws Exception {
+        Path inside = tmp.resolve("inside.txt");
+        Files.write(inside, "content".getBytes(StandardCharsets.UTF_8));
+
+        Config conf = new Config();
+        FileProtocol protocol = new FileProtocol();
+        protocol.configure(conf);
+
+        String url = inside.toUri().toURL().toString();
+        ProtocolResponse response = protocol.getProtocolOutput(url, new Metadata());
+        Assertions.assertEquals(
+                403, response.getStatusCode(), "FileProtocol served a file with no root set");
+    }
+
+    /**
+     * With a root directory configured, FileProtocol must refuse to read a file outside that root.
+     */
+    @Test
+    void fileProtocolConfinesReadsToConfiguredRoot(@TempDir Path tmp) throws Exception {
+        Path base = tmp.toRealPath();
+        Path root = base.resolve("root");
+        Files.createDirectories(root);
+        Path inside = root.resolve("inside.txt");
+        Files.write(inside, "for the crawler".getBytes(StandardCharsets.UTF_8));
+        Path outside = base.resolve("outside.txt");
+        Files.write(outside, "not for the crawler".getBytes(StandardCharsets.UTF_8));
+
+        Config conf = new Config();
+        conf.put(FileProtocol.ROOT_KEY, root.toString());
+
+        FileProtocol protocol = new FileProtocol();
+        protocol.configure(conf);
+
+        String insideUrl = inside.toUri().toURL().toString();
+        ProtocolResponse response = protocol.getProtocolOutput(insideUrl, new Metadata());
+        Assertions.assertEquals(
+                200, response.getStatusCode(), "FileProtocol refused a file inside the root");
+
+        String outsideUrl = outside.toUri().toURL().toString();
+        response = protocol.getProtocolOutput(outsideUrl, new Metadata());
+        Assertions.assertNotEquals(
+                200,
+                response.getStatusCode(),
+                "FileProtocol read a file outside the configured root: " + outsideUrl);
+    }
+
+    /** A symlink or parent-directory escape must not leave the root either. */
+    @Test
+    void fileProtocolConfinesCanonicalisedPaths(@TempDir Path tmp) throws Exception {
+        Path base = tmp.toRealPath();
+        Path root = base.resolve("root");
+        Files.createDirectories(root);
+        Path secret = base.resolve("secret.txt");
+        Files.write(secret, "not for the crawler".getBytes(StandardCharsets.UTF_8));
+
+        File link = root.resolve("link.txt").toFile();
+        try {
+            Files.createSymbolicLink(
+                    link.toPath().toAbsolutePath(), secret.toAbsolutePath());
+        } catch (UnsupportedOperationException | java.io.IOException e) {
+            // filesystem without symlink support; nothing to test here
+            return;
+        }
+
+        Config conf = new Config();
+        conf.put(FileProtocol.ROOT_KEY, root.toString());
+        FileProtocol protocol = new FileProtocol();
+        protocol.configure(conf);
+
+        String url = link.toURI().toURL().toString();
+        ProtocolResponse response = protocol.getProtocolOutput(url, new Metadata());
+        Assertions.assertNotEquals(
+                200,
+                response.getStatusCode(),
+                "FileProtocol followed a symlink out of the configured root: " + url);
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
@@ -17,13 +17,6 @@
 
 package org.apache.stormcrawler.protocol.file;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import org.apache.storm.Config;
 import org.apache.storm.utils.Utils;
 import org.apache.stormcrawler.Metadata;
@@ -32,6 +25,14 @@ import org.apache.stormcrawler.util.ConfUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 class FileProtocolDefaultsTest {
 
@@ -48,9 +49,7 @@ class FileProtocolDefaultsTest {
                 "crawler-default.yaml enables the file scheme by default: " + protocols);
     }
 
-    /**
-     * Without a configured root, FileProtocol must refuse to serve anything.
-     */
+    /** Without a configured root, FileProtocol must refuse to serve anything. */
     @Test
     void fileProtocolServesNothingWithoutARoot(@TempDir Path tmp) throws Exception {
         Path inside = tmp.resolve("inside.txt");
@@ -109,8 +108,7 @@ class FileProtocolDefaultsTest {
 
         File link = root.resolve("link.txt").toFile();
         try {
-            Files.createSymbolicLink(
-                    link.toPath().toAbsolutePath(), secret.toAbsolutePath());
+            Files.createSymbolicLink(link.toPath().toAbsolutePath(), secret.toAbsolutePath());
         } catch (UnsupportedOperationException | java.io.IOException e) {
             // filesystem without symlink support; nothing to test here
             return;
@@ -127,5 +125,24 @@ class FileProtocolDefaultsTest {
                 200,
                 response.getStatusCode(),
                 "FileProtocol followed a symlink out of the configured root: " + url);
+    }
+
+    /** A URL carrying a host component is refused: the file scheme serves local paths only. */
+    @Test
+    void fileProtocolRejectsHostComponents(@TempDir Path tmp) throws Exception {
+        Path root = tmp.toRealPath().resolve("root");
+        Files.createDirectories(root);
+
+        Config conf = new Config();
+        conf.put(FileProtocol.ROOT_KEY, root.toString());
+        FileProtocol protocol = new FileProtocol();
+        protocol.configure(conf);
+
+        String url = "file://evil.example.com/etc/passwd";
+        ProtocolResponse response = protocol.getProtocolOutput(url, new Metadata());
+        Assertions.assertNotEquals(
+                200,
+                response.getStatusCode(),
+                "FileProtocol accepted a file URL with a host component: " + url);
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
@@ -17,6 +17,13 @@
 
 package org.apache.stormcrawler.protocol.file;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import org.apache.storm.Config;
 import org.apache.storm.utils.Utils;
 import org.apache.stormcrawler.Metadata;
@@ -25,14 +32,6 @@ import org.apache.stormcrawler.util.ConfUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 class FileProtocolDefaultsTest {
 

--- a/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/protocol/file/FileProtocolDefaultsTest.java
@@ -120,8 +120,11 @@ class FileProtocolDefaultsTest {
 
         String url = link.toURI().toURL().toString();
         ProtocolResponse response = protocol.getProtocolOutput(url, new Metadata());
-        Assertions.assertNotEquals(
-                200,
+        // 403 specifically: the root confinement rejects the resolved target,
+        // which is what distinguishes it from the 300 the canonical-path
+        // redirect branch would otherwise give for any symlink inside the root
+        Assertions.assertEquals(
+                403,
                 response.getStatusCode(),
                 "FileProtocol followed a symlink out of the configured root: " + url);
     }
@@ -131,16 +134,22 @@ class FileProtocolDefaultsTest {
     void fileProtocolRejectsHostComponents(@TempDir Path tmp) throws Exception {
         Path root = tmp.toRealPath().resolve("root");
         Files.createDirectories(root);
+        // a real file inside the root: without the host check the request
+        // below would resolve to this readable file and return 200
+        Path readable = root.resolve("inside.txt");
+        Files.write(readable, "content".getBytes(StandardCharsets.UTF_8));
 
         Config conf = new Config();
         conf.put(FileProtocol.ROOT_KEY, root.toString());
         FileProtocol protocol = new FileProtocol();
         protocol.configure(conf);
 
-        String url = "file://evil.example.com/etc/passwd";
+        // the path of the file that is inside the root, requested with a host
+        String relativePath = "/inside.txt";
+        String url = "file://evil.example.com" + relativePath;
         ProtocolResponse response = protocol.getProtocolOutput(url, new Metadata());
-        Assertions.assertNotEquals(
-                200,
+        Assertions.assertEquals(
+                403,
                 response.getStatusCode(),
                 "FileProtocol accepted a file URL with a host component: " + url);
     }

--- a/docs/src/main/asciidoc/configuration.adoc
+++ b/docs/src/main/asciidoc/configuration.adoc
@@ -230,7 +230,7 @@ implementation.
 | https.protocol.implementation | org.apache.stormcrawler.protocol.okhttp.HttpProtocol | HTTPS Protocol
 implementation.
 | partition.url.mode | byHost | Defines how URLs are partitioned: byHost, byDomain, or byIP.
-| protocols | http,https,file | Supported protocols.
+| protocols | http,https | Supported protocols. The `file` scheme is not enabled by default; a crawl of a local corpus has to add it explicitly and confine reads with `file.protocol.root`.
 | redirections.allowed | true | If true, emit redirect target URLs as "outlinks" to the status stream. If false, do not follow redirects. See also `http.allow.redirects`.
 | http.allow.redirects | false | (OkHttp only) Follow HTTP redirects immediately in the HTTP protocol client. Note: if followed immediately, redirect target URLs are not emitted to the status stream, are not filtered, not deduplicated, and not checked against robots.txt.
 | sitemap.discovery | false | Enable automatic sitemap discovery.
@@ -244,6 +244,7 @@ implementation.
 | key | default value | description
 
 | file.protocol.implementation | org.apache.stormcrawler.protocol.file.FileProtocol | Protocol implementation for file:// URLs.
+| file.protocol.root | - | Directory that FileProtocol reads are confined to (used when the `file` scheme is enabled). Only paths canonicalising below this directory are served; everything else, including symlinks escaping it, returns 403, and a file URL carrying a host component is refused. Without it the file scheme serves nothing.
 | file.encoding | UTF-8 | Encoding for FileProtocol.
 | protocol.instances.num | 1 | Number of instances per protocol implementation.
 | http.protocol.versions | - | HTTP protocol versions in order of preference (h2, http/1.1, http/1.0, h2c). If empty, uses implementation defaults.


### PR DESCRIPTION
Fixes #2081.

`crawler-default.yaml` shipped `protocols: "http,https,file"`, and `FileProtocol` read whatever path the worker user could read: a fetched page can put a `file://` URL into the frontier (absolute `file://` hrefs resolve to themselves in the parser), and the response body — including the topology configuration and the backend credentials in it — went on to be parsed and indexed. The only gate was URL filtering, and the library default ships no URL filters at all.

- the shipped `protocols` list is now `http,https`; enabling the file scheme is a deliberate act
- `FileProtocol` gains `file.protocol.root`: when set, only paths canonicalising below that directory are served (symlinks included), everything else returns 403
- when no root is set, the file scheme serves nothing — reading any path requires having chosen a root on purpose

**Release note needed:** topologies crawling local corpora on the old default stop working until they add `file` to `protocols` and set `file.protocol.root`.