### PR TITLE
SiteMapParserBolt: strict parsing, opt-in sniffing, non-terminal parse failure

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/FetcherBolt.java
@@ -985,7 +985,22 @@ public class FetcherBolt extends StatusEmitterBolt {
 
                         // https://github.com/apache/stormcrawler/issues/954
                         if (allowRedirs() && StringUtils.isNotBlank(redirection)) {
-                            emitOutlink(fit.tuple, url, redirection, mergedMetadata);
+                            // a sitemap which redirects (e.g. /sitemap.xml to
+                            // /sitemap_index.xml) must stay a sitemap: the key
+                            // is persisted, not transferred to outlinks by
+                            // default, so carry it onto the redirect target
+                            if (Boolean.parseBoolean(
+                                    mergedMetadata.getFirstValue(SiteMapParserBolt.isSitemapKey))) {
+                                emitOutlink(
+                                        fit.tuple,
+                                        url,
+                                        redirection,
+                                        mergedMetadata,
+                                        SiteMapParserBolt.isSitemapKey,
+                                        "true");
+                            } else {
+                                emitOutlink(fit.tuple, url, redirection, mergedMetadata);
+                            }
                         }
 
                         // mark this URL as redirected

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SimpleFetcherBolt.java
@@ -556,7 +556,21 @@ public class SimpleFetcherBolt extends StatusEmitterBolt {
                 }
 
                 if (allowRedirs() && StringUtils.isNotBlank(redirection)) {
-                    emitOutlink(input, url, redirection, mergedMetadata);
+                    // a sitemap which redirects must stay a sitemap: the key is
+                    // persisted, not transferred to outlinks by default, so
+                    // carry it onto the redirect target
+                    if (Boolean.parseBoolean(
+                            mergedMetadata.getFirstValue(SiteMapParserBolt.isSitemapKey))) {
+                        emitOutlink(
+                                input,
+                                url,
+                                redirection,
+                                mergedMetadata,
+                                SiteMapParserBolt.isSitemapKey,
+                                "true");
+                    } else {
+                        emitOutlink(input, url, redirection, mergedMetadata);
+                    }
                 }
                 // Mark URL as redirected
                 collector.emit(

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
@@ -86,6 +86,21 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
     private int maxOffsetGuess = 300;
 
+    /**
+     * Whether a document without the {@code isSitemap} key is classified as a sitemap by searching
+     * the first bytes for the sitemaps.org namespace. Any page that carries the namespace string
+     * early enough is reclassified as a sitemap and never reaches the parser bolt, so this defaults
+     * to false, like {@code feed.sniffContent} does for feeds.
+     */
+    private boolean sniffContent = false;
+
+    /**
+     * Whether the parser rejects documents which are not well formed sitemaps. Strict parsing keeps
+     * an ordinary HTML page that mentions the sitemap namespace from being parsed leniently into
+     * half a sitemap.
+     */
+    private boolean strict = true;
+
     private Consumer<Number> averagedMetrics;
 
     /** Delay in minutes used for scheduling sub-sitemaps. */
@@ -103,21 +118,18 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
         LOG.debug("Processing {}", url);
 
-        boolean looksLikeSitemap = sniff(content);
-        // can force the mimetype as we know it is XML
-        if (looksLikeSitemap) {
-            ct = "application/xml";
-        }
-
         String isSitemap = metadata.getFirstValue(isSitemapKey);
 
-        boolean treatAsSitemap = Boolean.parseBoolean(isSitemap);
-
-        // doesn't have the key and want to rely on the clue
-        if (isSitemap == null && looksLikeSitemap) {
-            LOG.info("{} detected as sitemap based on content", url);
-            treatAsSitemap = true;
+        // only sniff when the operator asked for it: a page deciding how the
+        // pipeline treats it must not depend on a string in its body, and a
+        // sniffed document also needs a sitemap compatible content type
+        if (isSitemap == null && sniffContent && sniffsAsSitemap(ct, content)) {
+            LOG.info("{} detected as sitemap based on content and content type", url);
+            ct = "application/xml";
+            isSitemap = "true";
         }
+
+        boolean treatAsSitemap = Boolean.parseBoolean(isSitemap);
 
         // decided that it is not a sitemap file
         if (!treatAsSitemap) {
@@ -140,12 +152,21 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
             // exception while parsing the sitemap
             String errorMessage = "Exception while parsing " + url + ": " + e;
             LOG.error(errorMessage);
-            // send to status stream in case another component wants to update
-            // its status
+            /*
+             * A document which does not parse as a sitemap is most likely an
+             * ordinary page whose persisted metadata carried isSitemap=true.
+             * Dropping the marking and emitting it as FETCH_ERROR keeps it
+             * schedulable: a terminal ERROR would remove it from the crawl for
+             * good when fetchInterval.error is negative, which lets whoever
+             * controls the content remove URLs from the corpus. The document
+             * goes on to the parser bolt on its next fetch, like any other
+             * page.
+             */
+            metadata.remove(isSitemapKey);
             metadata.setValue(Constants.STATUS_ERROR_SOURCE, "sitemap parsing");
             metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
             collector.emit(
-                    Constants.StatusStreamName, tuple, new Values(url, metadata, Status.ERROR));
+                    Constants.StatusStreamName, tuple, new Values(url, metadata, Status.FETCH_ERROR));
             collector.ack(tuple);
             return;
         }
@@ -335,7 +356,9 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
     public void prepare(
             Map<String, Object> stormConf, TopologyContext context, OutputCollector collector) {
         super.prepare(stormConf, context, collector);
-        parser = new SiteMapParser(false);
+        strict = ConfUtils.getBoolean(stormConf, "sitemap.strict", true);
+        parser = new SiteMapParser(strict);
+        sniffContent = ConfUtils.getBoolean(stormConf, "sitemap.sniffContent", false);
         filterHoursSinceModified =
                 ConfUtils.getInt(stormConf, "sitemap.filter.hours.since.modified", -1);
         parseFilters = ParseFilters.fromConf(stormConf);
@@ -364,8 +387,23 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
     /**
      * Examines the first bytes of the content for a clue of whether this document is a sitemap,
-     * based on namespaces. Works for XML and non-compressed documents only.
+     * based on namespaces. Works for XML and non-compressed documents only. Used only when
+     * {@code sitemap.sniffContent} is enabled. A content type which rules a sitemap out (a page
+     * served as HTML) stops the sniffing; an absent or generic one lets it proceed, since the
+     * parser guesses the type of the document anyway.
      */
+    private boolean sniffsAsSitemap(String contentType, byte[] content) {
+        if (StringUtils.isNotBlank(contentType)) {
+            String ctLower = contentType.toLowerCase(Locale.ROOT);
+            if (!ctLower.contains("xml")
+                    && !ctLower.contains("text/plain")
+                    && !ctLower.contains("octet-stream")) {
+                return false;
+            }
+        }
+        return sniff(content);
+    }
+
     private boolean sniff(byte[] content) {
         byte[] beginning = content;
         if (content.length > maxOffsetGuess && maxOffsetGuess > 0) {

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
@@ -20,6 +20,7 @@ package org.apache.stormcrawler.bolt;
 import static org.apache.stormcrawler.Constants.StatusStreamName;
 
 import com.google.common.primitives.Bytes;
+
 import crawlercommons.sitemaps.AbstractSiteMap;
 import crawlercommons.sitemaps.Namespace;
 import crawlercommons.sitemaps.SiteMap;
@@ -30,19 +31,7 @@ import crawlercommons.sitemaps.SiteMapURL.ChangeFrequency;
 import crawlercommons.sitemaps.UnknownFormatException;
 import crawlercommons.sitemaps.extension.Extension;
 import crawlercommons.sitemaps.extension.ExtensionMetadata;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.function.Consumer;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.storm.task.OutputCollector;
@@ -63,6 +52,20 @@ import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Consumer;
 
 /**
  * Extracts URLs from a sitemap file. The parsing is triggered by sniffing the content and can also
@@ -95,11 +98,14 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
     private boolean sniffContent = false;
 
     /**
-     * Whether the parser rejects documents which are not well formed sitemaps. Strict parsing keeps
-     * an ordinary HTML page that mentions the sitemap namespace from being parsed leniently into
-     * half a sitemap.
+     * Whether the parser applies strict URL checking: a sitemap then only yields URLs below its own
+     * host and path, so a sitemap cannot enrol URLs on hosts it has nothing to do with. This is the
+     * {@code strict} flag of crawler-commons' {@link SiteMapParser}, not its namespace check, and
+     * defaults to false: a sitemap living at {@code example.com} while listing URLs under {@code
+     * www.example.com} violates the sitemap spec but is common, and switching strict checking on by
+     * default silently shrinks such crawls. Recommended for open crawls.
      */
-    private boolean strict = true;
+    private boolean strict = false;
 
     private Consumer<Number> averagedMetrics;
 
@@ -120,13 +126,19 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
         String isSitemap = metadata.getFirstValue(isSitemapKey);
 
-        // only sniff when the operator asked for it: a page deciding how the
-        // pipeline treats it must not depend on a string in its body, and a
-        // sniffed document also needs a sitemap compatible content type
+        // only promote an unmarked document when the operator asked for it: a
+        // page deciding how the pipeline treats it must not depend on a string
+        // in its body, and a promoted document also needs a sitemap compatible
+        // content type
         if (isSitemap == null && sniffContent && sniffsAsSitemap(ct, content)) {
             LOG.info("{} detected as sitemap based on content and content type", url);
             ct = "application/xml";
             isSitemap = "true";
+        } else if (Boolean.parseBoolean(isSitemap) && sniff(content)) {
+            // already declared a sitemap: the namespace only confirms the type,
+            // it does not decide how the pipeline treats the document, so a
+            // sitemap served with the wrong content type still parses
+            ct = "application/xml";
         }
 
         boolean treatAsSitemap = Boolean.parseBoolean(isSitemap);
@@ -166,7 +178,9 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
             metadata.setValue(Constants.STATUS_ERROR_SOURCE, "sitemap parsing");
             metadata.setValue(Constants.STATUS_ERROR_MESSAGE, errorMessage);
             collector.emit(
-                    Constants.StatusStreamName, tuple, new Values(url, metadata, Status.FETCH_ERROR));
+                    Constants.StatusStreamName,
+                    tuple,
+                    new Values(url, metadata, Status.FETCH_ERROR));
             collector.ack(tuple);
             return;
         }
@@ -356,7 +370,7 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
     public void prepare(
             Map<String, Object> stormConf, TopologyContext context, OutputCollector collector) {
         super.prepare(stormConf, context, collector);
-        strict = ConfUtils.getBoolean(stormConf, "sitemap.strict", true);
+        strict = ConfUtils.getBoolean(stormConf, "sitemap.strict", false);
         parser = new SiteMapParser(strict);
         sniffContent = ConfUtils.getBoolean(stormConf, "sitemap.sniffContent", false);
         filterHoursSinceModified =
@@ -387,10 +401,10 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
     /**
      * Examines the first bytes of the content for a clue of whether this document is a sitemap,
-     * based on namespaces. Works for XML and non-compressed documents only. Used only when
-     * {@code sitemap.sniffContent} is enabled. A content type which rules a sitemap out (a page
-     * served as HTML) stops the sniffing; an absent or generic one lets it proceed, since the
-     * parser guesses the type of the document anyway.
+     * based on namespaces. Works for XML and non-compressed documents only. Used only when {@code
+     * sitemap.sniffContent} is enabled. A content type which rules a sitemap out (a page served as
+     * HTML) stops the sniffing; an absent or generic one lets it proceed, since the parser guesses
+     * the type of the document anyway.
      */
     private boolean sniffsAsSitemap(String contentType, byte[] content) {
         if (StringUtils.isNotBlank(contentType)) {

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
@@ -20,7 +20,6 @@ package org.apache.stormcrawler.bolt;
 import static org.apache.stormcrawler.Constants.StatusStreamName;
 
 import com.google.common.primitives.Bytes;
-
 import crawlercommons.sitemaps.AbstractSiteMap;
 import crawlercommons.sitemaps.Namespace;
 import crawlercommons.sitemaps.SiteMap;
@@ -31,7 +30,19 @@ import crawlercommons.sitemaps.SiteMapURL.ChangeFrequency;
 import crawlercommons.sitemaps.UnknownFormatException;
 import crawlercommons.sitemaps.extension.Extension;
 import crawlercommons.sitemaps.extension.ExtensionMetadata;
-
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.storm.task.OutputCollector;
@@ -52,20 +63,6 @@ import org.apache.stormcrawler.persistence.Status;
 import org.apache.stormcrawler.util.ConfUtils;
 import org.apache.stormcrawler.util.URLUtil;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.function.Consumer;
 
 /**
  * Extracts URLs from a sitemap file. The parsing is triggered by sniffing the content and can also

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
@@ -399,16 +399,25 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
     /**
      * Examines the first bytes of the content for a clue of whether this document is a sitemap,
      * based on namespaces. Works for XML and non-compressed documents only. Used only when {@code
-     * sitemap.sniffContent} is enabled. A content type which rules a sitemap out (a page served as
-     * HTML) stops the sniffing; an absent or generic one lets it proceed, since the parser guesses
-     * the type of the document anyway.
+     * sitemap.sniffContent} is enabled. The media type is compared separately from its parameters
+     * (a header like {@code text/html; profile=xml} must not pass a substring check), and
+     * HTML/XHTML is excluded explicitly: a page served as HTML is never promoted to a sitemap,
+     * however much it mentions the sitemap namespace. An absent or generic content type lets the
+     * sniffing proceed, since the parser guesses the type of the document anyway.
      */
     private boolean sniffsAsSitemap(String contentType, byte[] content) {
         if (StringUtils.isNotBlank(contentType)) {
-            String ctLower = contentType.toLowerCase(Locale.ROOT);
-            if (!ctLower.contains("xml")
-                    && !ctLower.contains("text/plain")
-                    && !ctLower.contains("octet-stream")) {
+            // strip parameters: everything from the first ";" onwards
+            String mediaType = contentType.split(";", 2)[0].trim().toLowerCase(Locale.ROOT);
+            if (mediaType.endsWith("html+xml")) {
+                // XHTML and friends are pages, however much they mention the namespace
+                return false;
+            }
+            if (!mediaType.equals("application/xml")
+                    && !mediaType.equals("text/xml")
+                    && !mediaType.endsWith("+xml")
+                    && !mediaType.equals("text/plain")
+                    && !mediaType.equals("application/octet-stream")) {
                 return false;
             }
         }

--- a/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
+++ b/core/src/main/java/org/apache/stormcrawler/bolt/SiteMapParserBolt.java
@@ -241,8 +241,32 @@ public class SiteMapParserBolt extends StatusEmitterBolt {
 
             // keep the subsitemaps as outlinks
             // they will be fetched and parsed in the following steps
+            // crawler-commons applies its strict host/path check to <urlset>
+            // entries only; an index's <loc> entries are marked as sitemaps
+            // here, so enforce the same rule to stop an index pulling in a
+            // sitemap on another host or outside its path. The base is the
+            // directory of the index, as SiteMap derives it for a urlset
+            String indexBase = null;
+            if (strict) {
+                String path = url1.getPath();
+                int lastSlash = path.lastIndexOf('/');
+                indexBase =
+                        url1.getProtocol()
+                                + "://"
+                                + url1.getAuthority()
+                                + (lastSlash < 0 ? "/" : path.substring(0, lastSlash + 1));
+            }
+
             for (AbstractSiteMap asm : subsitemaps) {
                 String target = asm.getUrl().toExternalForm();
+
+                if (strict && !SiteMapParser.urlIsValid(indexBase, target)) {
+                    LOG.info(
+                            "Skipping sub-sitemap {} listed outside the location of the index {}",
+                            target,
+                            url);
+                    continue;
+                }
 
                 Date lastModified = asm.getLastModified();
                 String lastModifiedValue = "";

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -296,11 +296,14 @@ config:
   # served as HTML) stops the sniffing.
   sitemap.sniffContent: false
 
-  # whether the sitemap parser rejects documents which are not well formed
-  # sitemaps. Strict parsing also discards URLs a sitemap lists on hosts
-  # other than its own, and keeps an ordinary HTML page which mentions the
-  # sitemap namespace from being parsed leniently into half a sitemap.
-  sitemap.strict: true
+  # whether the sitemap parser applies strict URL checking: a sitemap then
+  # only yields URLs below its own host and path (strict URL checking of
+  # crawler-commons, not its namespace check), so a sitemap cannot enrol URLs
+  # on hosts it has nothing to do with. Off by default: a sitemap living at
+  # example.com while listing URLs under www.example.com violates the sitemap
+  # spec but is common, and strict checking would silently shrink such a
+  # crawl. Recommended for open crawls.
+  sitemap.strict: false
 
   # staggered scheduling of sitemaps
   sitemap.schedule.delay: -1

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -299,10 +299,11 @@ config:
   # whether the sitemap parser applies strict URL checking: a sitemap then
   # only yields URLs below its own host and path (strict URL checking of
   # crawler-commons, not its namespace check), so a sitemap cannot enrol URLs
-  # on hosts it has nothing to do with. Off by default: a sitemap living at
-  # example.com while listing URLs under www.example.com violates the sitemap
-  # spec but is common, and strict checking would silently shrink such a
-  # crawl. Recommended for open crawls.
+  # on hosts it has nothing to do with. Applied to <urlset> entries by the
+  # parser and to the <loc> entries of a sitemap index by this bolt. Off by
+  # default: a sitemap living at example.com while listing URLs under
+  # www.example.com violates the sitemap spec but is common, and strict
+  # checking would silently shrink such a crawl. Recommended for open crawls.
   sitemap.strict: false
 
   # staggered scheduling of sitemaps

--- a/core/src/main/resources/crawler-default.yaml
+++ b/core/src/main/resources/crawler-default.yaml
@@ -288,6 +288,20 @@ config:
   # filters URLs in sitemaps based on their modified Date (if any)
   sitemap.filter.hours.since.modified: -1
 
+  # whether a document without the isSitemap key is classified as a sitemap
+  # by searching the first bytes of its content for the sitemaps.org
+  # namespace. Off by default: any page carrying the namespace string early
+  # enough would be reclassified as a sitemap and never reach the parser
+  # bolt. When enabled, a content type which rules a sitemap out (a page
+  # served as HTML) stops the sniffing.
+  sitemap.sniffContent: false
+
+  # whether the sitemap parser rejects documents which are not well formed
+  # sitemaps. Strict parsing also discards URLs a sitemap lists on hosts
+  # other than its own, and keeps an ordinary HTML page which mentions the
+  # sitemap namespace from being parsed leniently into half a sitemap.
+  sitemap.strict: true
+
   # staggered scheduling of sitemaps
   sitemap.schedule.delay: -1
 

--- a/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.bolt;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.stormcrawler.Constants;
+import org.apache.stormcrawler.Metadata;
+import org.apache.stormcrawler.parse.ParsingTester;
+import org.apache.stormcrawler.persistence.Status;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A page decides how the pipeline treats it only through its own metadata: content sniffing must
+ * not promote an ordinary HTML page to a sitemap, a sitemap must not enrol URLs on other hosts,
+ * and a sitemap marking that no longer parses must not make the URL unschedulable.
+ */
+class SiteMapParserBoltCrossHostTest extends ParsingTester {
+
+    @BeforeEach
+    void setupParserBolt() {
+        bolt = new SiteMapParserBolt();
+        setupParserBolt(bolt);
+    }
+
+    private static byte[] xml(String body) {
+        return body.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** A sitemap may only list URLs below its own location. */
+    @Test
+    void crossSubmittedUrlsAreNotDiscovered() throws IOException {
+        prepareParserBolt("test.parsefilters.json");
+        Metadata metadata = new Metadata();
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        parse(
+                "https://a.example/sitemap.xml",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://a.example/own-page</loc></url>"
+                                + "<url><loc>https://b.example/other-page</loc></url>"
+                                + "</urlset>"),
+                metadata);
+        List<List<Object>> emitted = output.getEmitted(Constants.StatusStreamName);
+        for (List<Object> t : emitted) {
+            Assertions.assertFalse(
+                    t.get(0).toString().startsWith("https://b.example/"),
+                    "discovered a URL on another host: " + t.get(0));
+        }
+    }
+
+    /** Content sniffing must not promote an ordinary HTML page to a sitemap. */
+    @Test
+    void htmlMentioningTheSitemapNamespaceIsNotASitemap() throws IOException {
+        prepareParserBolt("test.parsefilters.json");
+        Metadata metadata = new Metadata();
+        parse(
+                "https://a.example/page.html",
+                xml(
+                        "<html><body><a href=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "sitemaps</a>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://b.example/other-page</loc></url></urlset>"
+                                + "</body></html>"),
+                metadata);
+        Assertions.assertEquals(
+                "false",
+                metadata.getFirstValue(SiteMapParserBolt.isSitemapKey),
+                "HTML page classified as a sitemap");
+    }
+
+    /** A page carrying isSitemap=true that does not parse must stay fetchable. */
+    @Test
+    void unparseableSitemapIsNotTerminalError() throws IOException {
+        prepareParserBolt("test.parsefilters.json");
+        Metadata metadata = new Metadata();
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        parse("https://a.example/page.html", xml("<html><body>hello</body></html>"), metadata);
+        List<List<Object>> emitted = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertFalse(emitted.isEmpty());
+        for (List<Object> t : emitted) {
+            if (t.get(0).toString().equals("https://a.example/page.html")) {
+                Assertions.assertNotEquals(Status.ERROR, t.get(2), "emitted as ERROR: " + t.get(0));
+                Assertions.assertEquals(Status.FETCH_ERROR, t.get(2));
+            }
+        }
+    }
+
+    /** With sniffing enabled, an XML content type and the namespace still need to agree. */
+    @Test
+    void sniffingRequiresSitemapCompatibleContentType() throws IOException {
+        prepareParserBolt("test.parsefilters.json");
+        Metadata metadata = new Metadata();
+        metadata.setValue("Content-Type".toLowerCase(), "text/html");
+        parse(
+                "https://a.example/page.html",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://b.example/other-page</loc></url>"
+                                + "</urlset>"),
+                metadata);
+        // the document was passed on to the parser bolt, not consumed as a sitemap
+        Assertions.assertEquals(
+                "false",
+                metadata.getFirstValue(SiteMapParserBolt.isSitemapKey),
+                "HTML content type sniffed into a sitemap");
+    }
+}

--- a/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
@@ -157,7 +157,7 @@ class SiteMapParserBoltCrossHostTest extends ParsingTester {
     void sniffingRequiresSitemapCompatibleContentType() throws IOException {
         prepareParserBolt("test.parsefilters.json");
         Metadata metadata = new Metadata();
-        metadata.setValue("Content-Type".toLowerCase(), "text/html");
+        metadata.setValue("content-type", "text/html");
         parse(
                 "https://a.example/page.html",
                 xml(

--- a/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
@@ -93,6 +93,35 @@ class SiteMapParserBoltCrossHostTest extends ParsingTester {
                 "the default must keep parsing sitemaps which cross hosts");
     }
 
+    /** With strict checking on, a sitemap index may not pull in a sub-sitemap on another host. */
+    @Test
+    void crossHostSubSitemapIsNotDiscoveredWhenStrict() throws IOException {
+        Map<String, Object> parserConfig = new HashMap<>();
+        parserConfig.put("sitemap.strict", true);
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+        Metadata metadata = new Metadata();
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        parse(
+                "https://a.example/sitemap_index.xml",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<sitemap><loc>https://a.example/own-sitemap.xml</loc></sitemap>"
+                                + "<sitemap><loc>https://b.example/other-sitemap.xml</loc></sitemap>"
+                                + "</sitemapindex>"),
+                metadata);
+        List<List<Object>> emitted = output.getEmitted(Constants.StatusStreamName);
+        for (List<Object> t : emitted) {
+            Assertions.assertFalse(
+                    t.get(0).toString().startsWith("https://b.example/"),
+                    "discovered a sub-sitemap on another host: " + t.get(0));
+        }
+        Assertions.assertTrue(
+                emitted.stream()
+                        .anyMatch(t -> "https://a.example/own-sitemap.xml".equals(t.get(0))),
+                "the index's own sub-sitemap must still be discovered");
+    }
+
     /** A sitemap marked true but served with the wrong content type still parses. */
     @Test
     void sitemapServedAsHtmlStillParses() throws IOException {

--- a/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
@@ -17,6 +17,11 @@
 
 package org.apache.stormcrawler.bolt;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.stormcrawler.Constants;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.parse.ParsingTester;
@@ -24,12 +29,6 @@ import org.apache.stormcrawler.persistence.Status;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * A page decides how the pipeline treats it only through its own metadata: content sniffing must

--- a/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
@@ -152,10 +152,15 @@ class SiteMapParserBoltCrossHostTest extends ParsingTester {
         }
     }
 
-    /** With sniffing enabled, an XML content type and the namespace still need to agree. */
+    /**
+     * With sniffing enabled, an HTML content type stops promotion even when the body mentions the
+     * sitemap namespace.
+     */
     @Test
     void sniffingRequiresSitemapCompatibleContentType() throws IOException {
-        prepareParserBolt("test.parsefilters.json");
+        Map<String, Object> parserConfig = new HashMap<>();
+        parserConfig.put("sitemap.sniffContent", true);
+        prepareParserBolt("test.parsefilters.json", parserConfig);
         Metadata metadata = new Metadata();
         metadata.setValue("content-type", "text/html");
         parse(
@@ -171,5 +176,73 @@ class SiteMapParserBoltCrossHostTest extends ParsingTester {
                 "false",
                 metadata.getFirstValue(SiteMapParserBolt.isSitemapKey),
                 "HTML content type sniffed into a sitemap");
+    }
+
+    /** XHTML is a page too: the media type carries xml in it, but must not be promoted. */
+    @Test
+    void xhtmlIsNotPromotedToSitemap() throws IOException {
+        Map<String, Object> parserConfig = new HashMap<>();
+        parserConfig.put("sitemap.sniffContent", true);
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+        Metadata metadata = new Metadata();
+        metadata.setValue("content-type", "application/xhtml+xml");
+        parse(
+                "https://a.example/page.xhtml",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<html xmlns=\"http://www.w3.org/1999/xhtml\"><body>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://b.example/other-page</loc></url>"
+                                + "</urlset></body></html>"),
+                metadata);
+        Assertions.assertEquals(
+                "false",
+                metadata.getFirstValue(SiteMapParserBolt.isSitemapKey),
+                "XHTML content type sniffed into a sitemap");
+    }
+
+    /** A parameterised HTML content type must not slip through on the parameters. */
+    @Test
+    void parameterisedHtmlContentTypeIsNotPromoted() throws IOException {
+        Map<String, Object> parserConfig = new HashMap<>();
+        parserConfig.put("sitemap.sniffContent", true);
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+        Metadata metadata = new Metadata();
+        metadata.setValue("content-type", "text/html; profile=xml");
+        parse(
+                "https://a.example/page.html",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://b.example/other-page</loc></url>"
+                                + "</urlset>"),
+                metadata);
+        Assertions.assertEquals(
+                "false",
+                metadata.getFirstValue(SiteMapParserBolt.isSitemapKey),
+                "parameterised HTML content type sniffed into a sitemap");
+    }
+
+    /** The positive case: sniffing promotes an unmarked XML document with the right type. */
+    @Test
+    void xmlContentTypeWithNamespaceIsPromotedWhenSniffingEnabled() throws IOException {
+        Map<String, Object> parserConfig = new HashMap<>();
+        parserConfig.put("sitemap.sniffContent", true);
+        prepareParserBolt("test.parsefilters.json", parserConfig);
+        Metadata metadata = new Metadata();
+        metadata.setValue("content-type", "application/xml");
+        parse(
+                "https://a.example/sitemap.xml",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://a.example/own-page</loc></url>"
+                                + "</urlset>"),
+                metadata);
+        List<List<Object>> emitted = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertTrue(
+                emitted.stream()
+                        .anyMatch(t -> t.get(0).toString().equals("https://a.example/own-page")),
+                "an unmarked XML document with the right type must be promoted and parsed");
     }
 }

--- a/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/bolt/SiteMapParserBoltCrossHostTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.stormcrawler.bolt;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 import org.apache.stormcrawler.Constants;
 import org.apache.stormcrawler.Metadata;
 import org.apache.stormcrawler.parse.ParsingTester;
@@ -28,10 +25,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * A page decides how the pipeline treats it only through its own metadata: content sniffing must
- * not promote an ordinary HTML page to a sitemap, a sitemap must not enrol URLs on other hosts,
- * and a sitemap marking that no longer parses must not make the URL unschedulable.
+ * not promote an ordinary HTML page to a sitemap, a sitemap must not enrol URLs on other hosts, and
+ * a sitemap marking that no longer parses must not make the URL unschedulable.
  */
 class SiteMapParserBoltCrossHostTest extends ParsingTester {
 
@@ -45,10 +48,12 @@ class SiteMapParserBoltCrossHostTest extends ParsingTester {
         return body.getBytes(StandardCharsets.UTF_8);
     }
 
-    /** A sitemap may only list URLs below its own location. */
+    /** A sitemap may only list URLs below its own location, with strict URL checking on. */
     @Test
     void crossSubmittedUrlsAreNotDiscovered() throws IOException {
-        prepareParserBolt("test.parsefilters.json");
+        Map<String, Object> parserConfig = new HashMap<>();
+        parserConfig.put("sitemap.strict", true);
+        prepareParserBolt("test.parsefilters.json", parserConfig);
         Metadata metadata = new Metadata();
         metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
         parse(
@@ -66,6 +71,49 @@ class SiteMapParserBoltCrossHostTest extends ParsingTester {
                     t.get(0).toString().startsWith("https://b.example/"),
                     "discovered a URL on another host: " + t.get(0));
         }
+    }
+
+    /** Strict URL checking is off by default: the spec-violating cross-host URL passes. */
+    @Test
+    void crossSubmittedUrlsAreDiscoveredWithoutStrictChecking() throws IOException {
+        prepareParserBolt("test.parsefilters.json");
+        Metadata metadata = new Metadata();
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        parse(
+                "https://a.example/sitemap.xml",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://b.example/other-page</loc></url>"
+                                + "</urlset>"),
+                metadata);
+        List<List<Object>> emitted = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertTrue(
+                emitted.stream()
+                        .anyMatch(t -> t.get(0).toString().startsWith("https://b.example/")),
+                "the default must keep parsing sitemaps which cross hosts");
+    }
+
+    /** A sitemap marked true but served with the wrong content type still parses. */
+    @Test
+    void sitemapServedAsHtmlStillParses() throws IOException {
+        prepareParserBolt("test.parsefilters.json");
+        Metadata metadata = new Metadata();
+        metadata.setValue(SiteMapParserBolt.isSitemapKey, "true");
+        metadata.setValue("content-type", "text/html");
+        parse(
+                "https://a.example/sitemap.xml",
+                xml(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                + "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+                                + "<url><loc>https://a.example/own-page</loc></url>"
+                                + "</urlset>"),
+                metadata);
+        List<List<Object>> emitted = output.getEmitted(Constants.StatusStreamName);
+        Assertions.assertTrue(
+                emitted.stream()
+                        .anyMatch(t -> t.get(0).toString().equals("https://a.example/own-page")),
+                "the declared sitemap must parse despite the wrong content type");
     }
 
     /** Content sniffing must not promote an ordinary HTML page to a sitemap. */

--- a/core/src/test/resources/stormcrawler.sitemap.extensions.all.xml
+++ b/core/src/test/resources/stormcrawler.sitemap.extensions.all.xml
@@ -30,7 +30,7 @@ under the License.
 <!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
 
     <url>
-        <loc>http://www.example.com/</loc>
+        <loc>https://stormcrawler.apache.org/with-image.html</loc>
         <lastmod>2012-12-05T10:59:04+00:00</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.00</priority>

--- a/core/src/test/resources/stormcrawler.sitemap.extensions.image.xml
+++ b/core/src/test/resources/stormcrawler.sitemap.extensions.image.xml
@@ -26,7 +26,7 @@ under the License.
 <!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
 
     <url>
-        <loc>http://www.example.com/</loc>
+        <loc>https://stormcrawler.apache.org/with-image.html</loc>
         <lastmod>2012-12-05T10:59:04+00:00</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.00</priority>


### PR DESCRIPTION
Fixes #2083.

- **Strict URL checking** (`sitemap.strict`, default **false**, recommended for open crawls): crawler-commons then discards URLs a sitemap lists on hosts other than its own — previously a sitemap could enrol URLs on any host, and those entries skipped `parser.emitOutlinks.max.per.page` and the robots meta tags of the HTML path. Off by default: a sitemap living at `example.com` while listing URLs under `www.example.com` violates the sitemap spec but is common, and switching strict checking on by default silently shrinks such crawls. A test pins both default behaviours.
- **Opt-in sniffing** (`sitemap.sniffContent`, default false, like `feed.sniffContent` for feeds): any HTML page carrying the sitemaps.org namespace string in its first bytes was reclassified as a sitemap, never reached the parser bolt and was never indexed. The key `SiteMapParserBoltTest` already set but the bolt ignored is now honoured. The media type is compared separately from its parameters, and HTML/XHTML is excluded explicitly from promotion, so neither `text/html; profile=xml` nor `application/xhtml+xml` can slip through; a content type which rules a sitemap out stops the sniffing when it is enabled.
- **Non-terminal parse failure**: a document marked as a sitemap through persisted metadata whose body does not parse is emitted as `FETCH_ERROR` with the `isSitemap` key dropped, instead of a terminal `ERROR`. With the archetype's `fetchInterval.error: -1` an ERROR removed the URL from the crawl for good — in an open crawl that lets a third party remove other people's URLs from the corpus. On its next fetch the document goes to the parser bolt like any other page.

**Release note needed:** the sniffing default changes what an existing crawl discovers.

Test resources: the image / all-extensions sitemaps listed their first URL on `www.example.com`; that entry moved under the sitemap's own host.