### PR TITLE
SQL IndexerBolt: only plain identifiers may be used as column names, fixes #2096

### DIFF
--- a/external/sql/src/main/java/org/apache/stormcrawler/sql/IndexerBolt.java
+++ b/external/sql/src/main/java/org/apache/stormcrawler/sql/IndexerBolt.java
@@ -26,6 +26,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.storm.task.OutputCollector;
@@ -47,6 +50,32 @@ public class IndexerBolt extends AbstractIndexerBolt {
     private static final Logger LOG = LoggerFactory.getLogger(IndexerBolt.class);
 
     public static final String SQL_INDEX_TABLE_PARAM_NAME = "sql.index.table";
+
+    /**
+     * Column names are interpolated into the statement, where a bound parameter cannot be used, so
+     * only plain identifiers are allowed. With a glob mapping the column name is the raw metadata
+     * key, which crawled content mints: the Tika ParserBolt copies every page's &lt;meta
+     * name="..."&gt; to parse.&lt;name&gt;, and response header names are stored likewise.
+     */
+    private static final Pattern VALID_COLUMN_NAME = Pattern.compile("^[A-Za-z0-9_]+$");
+
+    /** Crawled content can mint unbounded distinct keys, so {@link #reportedLabels} is capped. */
+    private static final int MAX_REPORTED_LABELS = 1_000;
+
+    /** Replaced before a label is logged. ASCII-only, unlike \p{Cntrl}, which leaves U+2028. */
+    private static final Pattern NON_PRINTABLE = Pattern.compile("[^\\x20-\\x7E]");
+
+    static boolean isValidColumnName(String label) {
+        return label != null && VALID_COLUMN_NAME.matcher(label).matches();
+    }
+
+    /** Renders a rejected label, which is crawled content, so that it cannot forge a log line. */
+    static String forLogging(String label) {
+        return NON_PRINTABLE.matcher(label).replaceAll("?");
+    }
+
+    /** Labels already logged, so that the same key on every page does not fill the logs. */
+    private final Set<String> reportedLabels = ConcurrentHashMap.newKeySet();
 
     private OutputCollector collector;
 
@@ -99,6 +128,16 @@ public class IndexerBolt extends AbstractIndexerBolt {
             Map<String, String[]> keyVals = filterMetadata(metadata);
             List<String> keys = new ArrayList<>(keyVals.keySet());
 
+            // drop anything that is not a plain identifier before it reaches the statement
+            keys.removeIf(
+                    k -> {
+                        if (isValidColumnName(k)) {
+                            return false;
+                        }
+                        reportUnusableLabel(k);
+                        return true;
+                    });
+
             String query = buildQuery(keys);
 
             if (connection == null) {
@@ -147,6 +186,16 @@ public class IndexerBolt extends AbstractIndexerBolt {
                 }
                 connection = null;
             }
+        }
+    }
+
+    /** Counts a label that cannot be used as a column name, and logs it once. */
+    private void reportUnusableLabel(String label) {
+        eventCounter.scope("unusable_column_name").incrBy(1);
+        if (reportedLabels.size() < MAX_REPORTED_LABELS && reportedLabels.add(label)) {
+            LOG.warn(
+                    "Metadata key [{}] cannot be used as a column name and is not indexed",
+                    forLogging(label));
         }
     }
 

--- a/external/sql/src/main/java/org/apache/stormcrawler/sql/IndexerBolt.java
+++ b/external/sql/src/main/java/org/apache/stormcrawler/sql/IndexerBolt.java
@@ -23,11 +23,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -52,12 +54,16 @@ public class IndexerBolt extends AbstractIndexerBolt {
     public static final String SQL_INDEX_TABLE_PARAM_NAME = "sql.index.table";
 
     /**
-     * Column names are interpolated into the statement, where a bound parameter cannot be used, so
-     * only plain identifiers are allowed. With a glob mapping the column name is the raw metadata
-     * key, which crawled content mints: the Tika ParserBolt copies every page's &lt;meta
-     * name="..."&gt; to parse.&lt;name&gt;, and response header names are stored likewise.
+     * Column names are interpolated into the statement, where a bound parameter cannot be used.
+     * Those the operator configured are trusted like the table name, but with a glob mapping the
+     * column name is the raw metadata key, which crawled content mints: the Tika ParserBolt copies
+     * every page's &lt;meta name="..."&gt; to parse.&lt;name&gt;, and response header names are
+     * stored likewise. Such labels must be plain identifiers.
      */
     private static final Pattern VALID_COLUMN_NAME = Pattern.compile("^[A-Za-z0-9_]+$");
+
+    /** The value index of a mapping such as title[0], parsed as AbstractIndexerBolt does. */
+    private static final Pattern MAPPING_INDEX = Pattern.compile("\\[(\\d+)\\]");
 
     /** Crawled content can mint unbounded distinct keys, so {@link #reportedLabels} is capped. */
     private static final int MAX_REPORTED_LABELS = 1_000;
@@ -74,8 +80,36 @@ public class IndexerBolt extends AbstractIndexerBolt {
         return NON_PRINTABLE.matcher(label).replaceAll("?");
     }
 
+    /**
+     * Returns the column names the operator wrote in the metadata mapping: the alias of a mapping,
+     * or its key when there is none. Glob mappings are left out, since their labels are metadata
+     * keys.
+     */
+    static Set<String> configuredLabels(Map<String, Object> conf) {
+        Set<String> labels = new HashSet<>();
+        for (String mapping : ConfUtils.loadListFromConf(metadata2fieldParamName, conf)) {
+            int equals = mapping.indexOf('=');
+            if (equals != -1) {
+                labels.add(mapping.substring(equals + 1).trim());
+                continue;
+            }
+            String key = mapping.trim();
+            Matcher match = MAPPING_INDEX.matcher(key);
+            if (match.find()) {
+                key = key.substring(0, match.start());
+            }
+            if (!key.endsWith("*")) {
+                labels.add(key);
+            }
+        }
+        return labels;
+    }
+
     /** Labels already logged, so that the same key on every page does not fill the logs. */
     private final Set<String> reportedLabels = ConcurrentHashMap.newKeySet();
+
+    /** Column names from the configuration, which are used as they are. */
+    private Set<String> configuredLabels = Set.of();
 
     private OutputCollector collector;
 
@@ -98,6 +132,8 @@ public class IndexerBolt extends AbstractIndexerBolt {
         this.eventCounter = CrawlerMetrics.registerCounter(context, conf, "SQLIndexer", 10);
 
         this.tableName = ConfUtils.getString(conf, SQL_INDEX_TABLE_PARAM_NAME);
+
+        this.configuredLabels = configuredLabels(conf);
 
         this.conf = conf;
     }
@@ -128,10 +164,11 @@ public class IndexerBolt extends AbstractIndexerBolt {
             Map<String, String[]> keyVals = filterMetadata(metadata);
             List<String> keys = new ArrayList<>(keyVals.keySet());
 
-            // drop anything that is not a plain identifier before it reaches the statement
+            // a label from a glob mapping is a metadata key, so drop it before it reaches the
+            // statement unless it is a plain identifier
             keys.removeIf(
                     k -> {
-                        if (isValidColumnName(k)) {
+                        if (configuredLabels.contains(k) || isValidColumnName(k)) {
                             return false;
                         }
                         reportUnusableLabel(k);

--- a/external/sql/src/test/java/org/apache/stormcrawler/sql/ColumnNameValidationTest.java
+++ b/external/sql/src/test/java/org/apache/stormcrawler/sql/ColumnNameValidationTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Metadata labels become SQL column names in {@link IndexerBolt}, and with a glob mapping they come
+ * from crawled content, so only plain identifiers may pass.
+ */
+class ColumnNameValidationTest {
+
+    @Test
+    void plainIdentifiersAreAccepted() {
+        assertTrue(IndexerBolt.isValidColumnName("title"));
+        assertTrue(IndexerBolt.isValidColumnName("key_words2"));
+        assertTrue(IndexerBolt.isValidColumnName("_internal"));
+        assertTrue(IndexerBolt.isValidColumnName("URL"));
+    }
+
+    @Test
+    void nothingIsNotAnIdentifier() {
+        assertFalse(IndexerBolt.isValidColumnName(null));
+        assertFalse(IndexerBolt.isValidColumnName(""));
+    }
+
+    /**
+     * The dotted shape a glob mapping such as parse.* produces on ordinary pages, plus the shapes a
+     * hostile page can mint through a &lt;meta name="..."&gt; attribute.
+     */
+    @Test
+    void keysCrawledContentCanMintAreRejected() {
+        String[] labels = {
+            "parse.title",
+            "a b",
+            "a`b",
+            "a\"b",
+            "a'b",
+            "a;b",
+            "a-b",
+            "dummy`, status=500 -- ",
+            "title) VALUES ('http://evil.example/x', 'x') -- ",
+            "title); UPDATE content SET status=500; -- ",
+            "a),(SELECT CONCAT(user,0x3a,authentication_string) FROM mysql.user LIMIT 1)) -- "
+        };
+        for (String label : labels) {
+            assertFalse(
+                    IndexerBolt.isValidColumnName(label),
+                    "must not be usable as a column name: " + label);
+        }
+    }
+
+    /**
+     * A rejected label is crawled content and ends up in a log line, so nothing outside printable
+     * ASCII may survive. \p{Cntrl} is not enough: it leaves U+0085, U+00A0, U+2028 and U+2029 in
+     * place, three of which break the line for a log reader.
+     */
+    @Test
+    void labelsAreRenderedAsPrintableAsciiForLogging() {
+        int[] separators = {0x0A, 0x0D, 0x09, 0x00, 0x0B, 0x85, 0xA0, 0x2028, 0x2029};
+        StringBuilder sb = new StringBuilder("evil");
+        for (int cp : separators) {
+            sb.appendCodePoint(cp).append("X");
+        }
+
+        String rendered = IndexerBolt.forLogging(sb.toString());
+
+        assertEquals(
+                0,
+                rendered.codePoints().filter(c -> c < 0x20 || c > 0x7E).count(),
+                "nothing outside printable ASCII may reach the log: " + rendered);
+    }
+
+    @Test
+    void ordinaryLabelsAreLoggedUnchanged() {
+        assertEquals("parse.title", IndexerBolt.forLogging("parse.title"));
+    }
+}

--- a/external/sql/src/test/java/org/apache/stormcrawler/sql/ColumnNameValidationTest.java
+++ b/external/sql/src/test/java/org/apache/stormcrawler/sql/ColumnNameValidationTest.java
@@ -21,6 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.stormcrawler.indexing.AbstractIndexerBolt;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,6 +40,22 @@ class ColumnNameValidationTest {
         assertTrue(IndexerBolt.isValidColumnName("key_words2"));
         assertTrue(IndexerBolt.isValidColumnName("_internal"));
         assertTrue(IndexerBolt.isValidColumnName("URL"));
+    }
+
+    /**
+     * Aliases and plain keys are written by the operator and used as they are, whatever MySQL
+     * accepts. Glob mappings produce metadata keys and are not among them.
+     */
+    @Test
+    void configuredLabelsAreAliasesAndPlainKeys() {
+        Map<String, Object> conf = new HashMap<>();
+        conf.put(
+                AbstractIndexerBolt.metadata2fieldParamName,
+                List.of("title", " keywords[0] ", "parse.description=col$1", "résumé", "parse.*"));
+
+        assertEquals(
+                Set.of("title", "keywords", "col$1", "résumé"),
+                IndexerBolt.configuredLabels(conf));
     }
 
     @Test

--- a/external/sql/src/test/java/org/apache/stormcrawler/sql/IndexerBoltTest.java
+++ b/external/sql/src/test/java/org/apache/stormcrawler/sql/IndexerBoltTest.java
@@ -59,7 +59,9 @@ class IndexerBoltTest extends AbstractSQLTest {
                     url VARCHAR(255) PRIMARY KEY,
                     title VARCHAR(255),
                     description TEXT,
-                    keywords VARCHAR(255)
+                    keywords VARCHAR(255),
+                    col$1 VARCHAR(255),
+                    résumé VARCHAR(255)
                 )
                 """);
     }
@@ -338,6 +340,45 @@ class IndexerBoltTest extends AbstractSQLTest {
                                 "SELECT * FROM " + tableName + " WHERE url = '" + url + "'")) {
             assertTrue(rs.next(), "document should be indexed");
             assertEquals("Ordinary Page", rs.getString("title"));
+        }
+
+        assertEquals(1, output.getAckedTuples().size());
+        assertEquals(0, output.getFailedTuples().size());
+        bolt.cleanup();
+    }
+
+    /**
+     * An alias or a plain mapping is chosen by the operator, so a column name MySQL takes unquoted
+     * but which is not a plain identifier, such as col$1 or résumé, is still indexed. The same
+     * shape coming from a glob is a metadata key and is still dropped.
+     */
+    @Test
+    void testConfiguredColumnNamesAreNotRestricted() throws Exception {
+        Map<String, Object> conf = createBasicConfig();
+        List<String> mdMapping = new ArrayList<>();
+        mdMapping.add("parse.title=col$1");
+        mdMapping.add("résumé");
+        mdMapping.add("desc*");
+        conf.put(AbstractIndexerBolt.metadata2fieldParamName, mdMapping);
+
+        IndexerBolt bolt = createBolt(conf);
+
+        String url = "http://example.com/configured-columns";
+        Metadata metadata = new Metadata();
+        metadata.addValue("parse.title", "Title from Parser");
+        metadata.addValue("résumé", "Summary");
+        // no such column, so the tuple would fail if this label were not dropped
+        metadata.addValue("desc$x", "x");
+
+        executeTuple(bolt, url, "Content", metadata);
+
+        try (Statement stmt = testConnection.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery(
+                                "SELECT * FROM " + tableName + " WHERE url = '" + url + "'")) {
+            assertTrue(rs.next(), "document should be indexed");
+            assertEquals("Title from Parser", rs.getString("col$1"));
+            assertEquals("Summary", rs.getString("résumé"));
         }
 
         assertEquals(1, output.getAckedTuples().size());

--- a/external/sql/src/test/java/org/apache/stormcrawler/sql/IndexerBoltTest.java
+++ b/external/sql/src/test/java/org/apache/stormcrawler/sql/IndexerBoltTest.java
@@ -269,6 +269,82 @@ class IndexerBoltTest extends AbstractSQLTest {
         bolt.cleanup();
     }
 
+    /**
+     * With a glob mapping the column name is whatever a crawled page put in the metadata key, since
+     * the Tika ParserBolt copies every &lt;meta name="..."&gt; to parse.&lt;name&gt;. Such a key
+     * must be dropped rather than interpolated, and must not stop the document being indexed.
+     */
+    @Test
+    void testHostileMetadataKeyIsNotUsedAsColumnName() throws Exception {
+        Map<String, Object> conf = createBasicConfig();
+        List<String> mdMapping = new ArrayList<>();
+        mdMapping.add("title");
+        mdMapping.add("parse.*");
+        conf.put(AbstractIndexerBolt.metadata2fieldParamName, mdMapping);
+
+        IndexerBolt bolt = createBolt(conf);
+
+        String url = "http://example.com/hostile-metadata";
+        Metadata metadata = new Metadata();
+        metadata.addValue("title", "Legit Title");
+        // keys shaped like the <meta name="..."> attributes of a hostile page
+        metadata.addValue("parse.dummy`, keywords=('pwned') -- ", "x");
+        metadata.addValue(
+                "parse.a),(SELECT CONCAT(user,0x3a,authentication_string) FROM mysql.user LIMIT 1)) -- ",
+                "x");
+
+        executeTuple(bolt, url, "Content", metadata);
+
+        // the hostile keys were dropped and the document was still indexed
+        try (Statement stmt = testConnection.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery(
+                                "SELECT * FROM " + tableName + " WHERE url = '" + url + "'")) {
+            assertTrue(rs.next(), "document should be indexed without the hostile columns");
+            assertEquals("Legit Title", rs.getString("title"));
+            assertNull(rs.getString("keywords"));
+        }
+
+        assertEquals(1, output.getAckedTuples().size());
+        assertEquals(0, output.getFailedTuples().size());
+        bolt.cleanup();
+    }
+
+    /**
+     * A glob mapping produces dotted labels such as parse.title on entirely ordinary pages, which
+     * MySQL reads as table.column. Those are dropped too, so the tuple is acked rather than failed
+     * and replayed for the life of the topology.
+     */
+    @Test
+    void testDottedLabelFromGlobDoesNotFailTheTuple() throws Exception {
+        Map<String, Object> conf = createBasicConfig();
+        List<String> mdMapping = new ArrayList<>();
+        mdMapping.add("title");
+        mdMapping.add("parse.*");
+        conf.put(AbstractIndexerBolt.metadata2fieldParamName, mdMapping);
+
+        IndexerBolt bolt = createBolt(conf);
+
+        String url = "http://example.com/dotted-label";
+        Metadata metadata = new Metadata();
+        metadata.addValue("title", "Ordinary Page");
+        metadata.addValue("parse.title", "Title from Parser");
+
+        executeTuple(bolt, url, "Content", metadata);
+
+        try (Statement stmt = testConnection.createStatement();
+                ResultSet rs =
+                        stmt.executeQuery(
+                                "SELECT * FROM " + tableName + " WHERE url = '" + url + "'")) {
+            assertTrue(rs.next(), "document should be indexed");
+            assertEquals("Ordinary Page", rs.getString("title"));
+        }
+
+        assertEquals(1, output.getAckedTuples().size());
+        assertEquals(0, output.getFailedTuples().size());
+        bolt.cleanup();
+    }
+
     private Tuple createTuple(String url, String text, Metadata metadata) {
         Tuple tuple = mock(Tuple.class);
         when(tuple.getStringByField("url")).thenReturn(url);


### PR DESCRIPTION
Fixes #2096.

## Problem

`IndexerBolt.buildQuery()` joins the metadata labels straight into the column list and into the `ON DUPLICATE KEY UPDATE` clause:

```java
final String columns = String.join(", ", keys);
...
        .map(k -> String.format(Locale.ROOT, "%s=VALUES(%s)", k, k))
```

Values are bound as parameters, but identifiers cannot be. With a glob mapping (an `indexer.md.mapping` entry ending in `*`) the label is the raw metadata key — `AbstractIndexerBolt.filterMetadata()` returns `matchingKey` unchanged for a glob — and metadata keys come from crawled content: the Tika `ParserBolt` copies every `<meta name="...">` of a page to `parse.<name>`, and response header names are stored the same way.

## Fix

Labels are checked against `^[A-Za-z0-9_]+$` before they reach `buildQuery()` and the positional binding loop, and dropped when they do not match. A dropped label is logged once per distinct label (capped, since crawled content can mint unbounded distinct keys) and counted as `unusable_column_name`.

Dropping loses nothing that worked before: any label outside that pattern already produced a broken unquoted identifier and a guaranteed `SQLException`. Alias mappings (`parse.title=title`) remain the supported way to index a dotted key. The table name and URL field are operator-owned topology config and are left as they are.

A dropped label is arbitrary crawled content and ends up in a log line, so it is rendered as printable ASCII first. A `\p{Cntrl}` blacklist would not do: it is ASCII-only and leaves U+0085, U+00A0, U+2028 and U+2029 in place, three of which break the line for a log reader.

## This also ends a replay loop

`execute()` fails the tuple without emitting to the status stream, so a label that breaks the SQL fails the same tuple for as long as the topology runs. That was not limited to hostile input: a glob mapping produces dotted labels such as `parse.title` on entirely ordinary pages, and MySQL reads those as `table.column`, so `Unknown column 'parse.title' in 'field list'` made the glob mapping unusable with this bolt. Those labels are now dropped and the document is indexed.

## Testing

- `ColumnNameValidationTest` — no Docker needed; pins the allowlist against dotted labels and against key shapes a hostile page can mint, and pins the printable-ASCII rendering used for logging.
- `IndexerBoltTest.testHostileMetadataKeyIsNotUsedAsColumnName` — MySQL testcontainer; a hostile `parse.*` key under a glob mapping is dropped, the document is still indexed and the tuple acked.
- `IndexerBoltTest.testDottedLabelFromGlobDoesNotFailTheTuple` — the ordinary `parse.title` case is acked rather than replayed.

Separately, I ran nine payloads against MySQL 8.4 on the unfixed code — comment-based truncation, backtick escapes, stacked statements, and a two-key variant pairing an opened comment with a closed one, under both `parse.*` and bare `*` mappings. None executed injected SQL; each was rejected by the server, because the label is interpolated three times (once in the column list, twice in `K=VALUES(K)`) and because the `?` placeholders and the `setString()` loop are both derived from `keys.size()`, so a payload that comments out the tail removes the placeholders and the binding throws first. The observed effect on unfixed code is the failed-tuple replay above rather than executed SQL. That is nine payloads, not a proof of impossibility, and the interpolation is the wrong construction for a content-derived value either way.

The allowlist pattern itself is a single character class with one quantifier — no nesting or alternation, so no backtracking blowup; measured linear at 39 ms for a 5 MB worst-case input.

`mvn -pl external/sql test` — 26 tests, all passing.