### PR TITLE
Minor: Fix formatting in ColumnNameValidationTest

### DIFF
--- a/external/sql/src/test/java/org/apache/stormcrawler/sql/ColumnNameValidationTest.java
+++ b/external/sql/src/test/java/org/apache/stormcrawler/sql/ColumnNameValidationTest.java
@@ -54,8 +54,7 @@ class ColumnNameValidationTest {
                 List.of("title", " keywords[0] ", "parse.description=col$1", "résumé", "parse.*"));
 
         assertEquals(
-                Set.of("title", "keywords", "col$1", "résumé"),
-                IndexerBolt.configuredLabels(conf));
+                Set.of("title", "keywords", "col$1", "résumé"), IndexerBolt.configuredLabels(conf));
     }
 
     @Test


### PR DESCRIPTION
Main currently fails the `validate-code-format` check because of a formatting issue in `ColumnNameValidationTest` (introduced in #2146). This applies the google-java-format (AOSP) output to that file. No functional changes.