### PR TITLE
URLFrontier StatusUpdaterBolt: make lock objects transient so the bolt can be serialized

### DIFF
--- a/external/urlfrontier/src/main/java/org/apache/stormcrawler/urlfrontier/StatusUpdaterBolt.java
+++ b/external/urlfrontier/src/main/java/org/apache/stormcrawler/urlfrontier/StatusUpdaterBolt.java
@@ -151,8 +151,12 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt
     /** batches sent but not acked yet, keyed by the ID echoed back in the BatchAck */
     private final Map<String, List<URLItem>> pendingBatches = new HashMap<>();
 
-    /** guards the batch buffer, the pending batches and the batch stream reference */
-    private final Object batchLock = new Object();
+    /**
+     * guards the batch buffer, the pending batches and the batch stream reference; created in
+     * prepare() as Object is not serializable and the bolt is serialized when the topology is
+     * submitted
+     */
+    private transient Object batchLock;
 
     /**
      * guards the onNext calls on both gRPC streams: they come from the Storm executor thread and
@@ -165,7 +169,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt
      * same thread when gRPC delivers an error synchronously; that is a same-thread monitor
      * re-entry, which the JVM allows, and it never blocks on another thread.
      */
-    private final Object sendLock = new Object();
+    private transient Object sendLock;
 
     private final AtomicInteger batchSequences = new AtomicInteger();
 
@@ -175,7 +179,7 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt
      * notified when permits are released and when a transport becomes ready, so that throttled
      * sends wake up as soon as they can proceed instead of polling
      */
-    private final Object flow = new Object();
+    private transient Object flow;
 
     /** set once the bolt is shutting down; the callbacks must not act on it anymore */
     private volatile boolean closed;
@@ -184,6 +188,10 @@ public class StatusUpdaterBolt extends AbstractStatusUpdaterBolt
     public void prepare(
             Map<String, Object> stormConf, TopologyContext context, OutputCollector collector) {
         super.prepare(stormConf, context, collector);
+
+        batchLock = new Object();
+        sendLock = new Object();
+        flow = new Object();
 
         var expireAfterNMillisec =
                 ConfUtils.getLong(stormConf, URLFRONTIER_CACHE_EXPIREAFTER_SEC_KEY, 60);

--- a/external/urlfrontier/src/test/java/org/apache/stormcrawler/urlfrontier/StatusUpdaterBoltSerializationTest.java
+++ b/external/urlfrontier/src/test/java/org/apache/stormcrawler/urlfrontier/StatusUpdaterBoltSerializationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.stormcrawler.urlfrontier;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+
+/** The bolt is java-serialized by Storm when the topology is submitted. */
+class StatusUpdaterBoltSerializationTest {
+
+    @Test
+    void survivesSerialization() throws Exception {
+        final ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+            oos.writeObject(new StatusUpdaterBolt());
+        }
+        try (ObjectInputStream ois =
+                new ObjectInputStream(new ByteArrayInputStream(bos.toByteArray()))) {
+            assertInstanceOf(StatusUpdaterBolt.class, ois.readObject());
+        }
+    }
+}


### PR DESCRIPTION
I noticed this while testing Storm 3.1.0 RC1: submitting a topology that uses the URLFrontier `StatusUpdaterBolt` fails with `java.io.NotSerializableException: java.lang.Object`. It is not a Storm regression, `TopologyBuilder` is the same in 3.0.0 and 3.1.0.

The cause is #2117, which replaced the `ReentrantLock` with plain `Object` monitors (`batchLock`, `sendLock`, `flow`) in final fields. `Object` is not serializable, so the bolt can no longer be serialized when the topology is submitted. 3.5.0 is not affected.

This makes the three monitors transient and creates them in `prepare()`. Also adds a small test that serializes and deserializes the bolt; it fails on current main and passes with the change. The existing `StatusUpdaterBoltTest` and `StatusUpdaterBoltFallbackTest` still pass.