### PR TITLE
#2102 Redact proxy credentials from worker logs

### DIFF
--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -404,10 +404,7 @@ public class HttpProtocol extends AbstractHttpProtocol {
                 }
 
                 LOG.debug(
-                        "fetching with proxy {} - {}:{} ",
-                        url,
-                        prox.getAddress(),
-                        prox.getPort());
+                        "fetching with proxy {} - {}:{} ", url, prox.getAddress(), prox.getPort());
             }
         }
 

--- a/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
+++ b/core/src/main/java/org/apache/stormcrawler/protocol/okhttp/HttpProtocol.java
@@ -403,7 +403,11 @@ public class HttpProtocol extends AbstractHttpProtocol {
                             System.currentTimeMillis() - buildStart);
                 }
 
-                LOG.debug("fetching with proxy {} - {} ", url, prox.toString());
+                LOG.debug(
+                        "fetching with proxy {} - {}:{} ",
+                        url,
+                        prox.getAddress(),
+                        prox.getPort());
             }
         }
 

--- a/core/src/main/java/org/apache/stormcrawler/proxy/SCProxy.java
+++ b/core/src/main/java/org/apache/stormcrawler/proxy/SCProxy.java
@@ -129,15 +129,15 @@ public class SCProxy {
         }
     }
 
-    /** Formats the proxy information into a URL compatible connection string. */
+    /** Formats the proxy information into a redacted URL compatible connection string. */
     public String toString() {
-        // assemble base string with address and password
+        // assemble base string with address and port
         String proxyString = this.address + ":" + this.port;
 
         // conditionally add authentication details
         if (this.username != null && this.password != null) {
             // re-assemble url with auth details prepended
-            proxyString = this.username + ":" + this.password + "@" + proxyString;
+            proxyString = this.username + ":***@" + proxyString;
         }
 
         // prepend protocol string to url and return

--- a/core/src/test/java/org/apache/stormcrawler/proxy/SCProxyTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/proxy/SCProxyTest.java
@@ -68,7 +68,15 @@ class SCProxyTest {
 
     @Test
     void testToString() {
-        String[] proxyStrings = {
+        String[] expectedProxyStrings = {
+            "http://example.com:8080",
+            "https://example.com:8080",
+            "http://user1:***@example.com:8080",
+            "sock5://user1:***@example.com:8080",
+            "http://example.com:80",
+            "sock5://example.com:64000"
+        };
+        String[] inputProxyStrings = {
             "http://example.com:8080",
             "https://example.com:8080",
             "http://user1:pass1@example.com:8080",
@@ -76,9 +84,12 @@ class SCProxyTest {
             "http://example.com:80",
             "sock5://example.com:64000"
         };
-        for (String proxyString : proxyStrings) {
-            SCProxy proxy = new SCProxy(proxyString);
-            Assertions.assertEquals(proxyString, proxy.toString());
+        for (int i = 0; i < inputProxyStrings.length; i++) {
+            SCProxy proxy = new SCProxy(inputProxyStrings[i]);
+            Assertions.assertEquals(expectedProxyStrings[i], proxy.toString());
+            if (proxy.getPassword() != null) {
+                Assertions.assertFalse(proxy.toString().contains(proxy.getPassword()));
+            }
         }
     }
 

--- a/core/src/test/java/org/apache/stormcrawler/proxy/SingleProxyManagerTest.java
+++ b/core/src/test/java/org/apache/stormcrawler/proxy/SingleProxyManagerTest.java
@@ -43,7 +43,7 @@ class SingleProxyManagerTest {
         Assertions.assertEquals("8080", proxy.getPort());
         Assertions.assertEquals("user1", proxy.getUsername());
         Assertions.assertEquals("pass1", proxy.getPassword());
-        Assertions.assertEquals("http://user1:pass1@example.com:8080", proxy.toString());
+        Assertions.assertEquals("http://user1:***@example.com:8080", proxy.toString());
     }
 
     @Test
@@ -131,7 +131,7 @@ class SingleProxyManagerTest {
         Optional<SCProxy> proxyOptional = pm.getProxy(metadata);
         Assertions.assertTrue(proxyOptional.isPresent());
         Assertions.assertEquals(
-                "https://metadata-user:metadata-pass@metadata.example.com:9443",
+                "https://metadata-user:***@metadata.example.com:9443",
                 proxyOptional.get().toString());
     }
 
@@ -187,7 +187,7 @@ class SingleProxyManagerTest {
         Optional<SCProxy> proxyOptional = pm.getProxy(metadata);
         Assertions.assertTrue(proxyOptional.isPresent());
         Assertions.assertEquals(
-                "http://user1:pass1@example.com:8080", proxyOptional.get().toString());
+                "http://user1:***@example.com:8080", proxyOptional.get().toString());
     }
 
     @Test


### PR DESCRIPTION
# Redact proxy credentials from worker logs

## The problem

`SCProxy.toString()` included the proxy username and password when credentials were configured:

```text
http://user:password@proxy.example.com:8080
```

`HttpProtocol` passed this value to `LOG.debug()` for every proxied fetch. When DEBUG logging was enabled, proxy credentials were therefore written to worker logs and could be shipped to central log aggregation.

These credentials may belong to paid third-party proxy services and should not be exposed to everyone with access to worker logs.

## What this PR changes

### Redact credentials in `SCProxy.toString()`

Authenticated proxies are now rendered as:

```text
http://user:***@proxy.example.com:8080
```

Unauthenticated proxies continue to render normally:

```text
http://proxy.example.com:8080
```

Proxy credentials remain available through `getUsername()` and `getPassword()` for the actual authentication flow. Equality and hashing are also unchanged because they operate directly on the proxy fields.

### Remove proxy stringification from OkHttp logging

The OkHttp protocol now logs only the proxy endpoint:

```text
fetching with proxy <url> - proxy.example.com:8080
```

This prevents the logging path from depending on the proxy's rendered representation.

## Compatibility impact

The rendered value of `SCProxy.toString()` is no longer a credential-bearing connection string. This is intentional because `toString()` may be used implicitly by logging and diagnostics.

No production code in this repository requires the full connection string from `toString()`. Proxy construction and authentication continue to use the individual proxy getters.

## Tests

Updated the existing proxy tests to verify the redacted representation for authenticated proxies while preserving the existing endpoint format for unauthenticated proxies.

The tests also continue to verify that:

- Proxy usernames and passwords are parsed correctly.
- Proxy authentication fields remain available through their getters.
- Proxy equality and hash codes still include credentials.
- Single-proxy manager configuration continues to work.
- Metadata proxy overrides continue to work.
- Multi-proxy rotation and lookup behavior are unchanged.
- OkHttp proxy handling remains thread-safe.

## Verification

```text
mvn -pl core test \
  -Dtest=SCProxyTest,SingleProxyManagerTest,MultiProxyManagerTest,HttpProtocolProxyConcurrencyTest
```

Result:

```text
Tests run: 42, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Also verified:

```text
git diff --check
```
